### PR TITLE
Temporarily disable part of the CI workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -30,33 +30,33 @@ jobs:
 
       - run: ./scripts/cibuild
 
-      - run: ./scripts/cipublish
-        if: |
-          github.ref == 'refs/heads/develop' ||
-          startsWith(github.ref, 'refs/heads/hotfix/') ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          startsWith(github.ref, 'refs/heads/test/')
-
-      - run: |
-          docker-compose -f docker-compose.ci.yml run --rm terraform -c "
-            # Unset this to avoid a ProfileNotFound exception from the AWS CLI.
-            unset AWS_PROFILE
-            ./scripts/infra plan
-            ./scripts/infra apply
-          "
-        env:
-          IOW_BOUNDARY_TOOL_ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
-          IOW_BOUNDARY_TOOL_DEPLOYMENT_ENVIRONMENT: staging
-        if: |
-          github.ref == 'refs/heads/develop' ||
-          startsWith(github.ref, 'refs/heads/hotfix/') ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          startsWith(github.ref, 'refs/heads/test/')
-
-      # Kick off an ECS task to display any outstanding migrations.
-      - run: ./scripts/manage ecsmanage showmigrations
-        if: |
-          github.ref == 'refs/heads/develop' ||
-          startsWith(github.ref, 'refs/heads/hotfix/') ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          startsWith(github.ref, 'refs/heads/test/')
+#       - run: ./scripts/cipublish
+#         if: |
+#           github.ref == 'refs/heads/develop' ||
+#           startsWith(github.ref, 'refs/heads/hotfix/') ||
+#           startsWith(github.ref, 'refs/heads/release/') ||
+#           startsWith(github.ref, 'refs/heads/test/')
+#
+#       - run: |
+#           docker-compose -f docker-compose.ci.yml run --rm terraform -c "
+#             # Unset this to avoid a ProfileNotFound exception from the AWS CLI.
+#             unset AWS_PROFILE
+#             ./scripts/infra plan
+#             ./scripts/infra apply
+#           "
+#         env:
+#           IOW_BOUNDARY_TOOL_ROLLBAR_ACCESS_TOKEN: ${{ secrets.ROLLBAR_ACCESS_TOKEN }}
+#           IOW_BOUNDARY_TOOL_DEPLOYMENT_ENVIRONMENT: staging
+#         if: |
+#           github.ref == 'refs/heads/develop' ||
+#           startsWith(github.ref, 'refs/heads/hotfix/') ||
+#           startsWith(github.ref, 'refs/heads/release/') ||
+#           startsWith(github.ref, 'refs/heads/test/')
+#
+#       # Kick off an ECS task to display any outstanding migrations.
+#       - run: ./scripts/manage ecsmanage showmigrations
+#         if: |
+#           github.ref == 'refs/heads/develop' ||
+#           startsWith(github.ref, 'refs/heads/hotfix/') ||
+#           startsWith(github.ref, 'refs/heads/release/') ||
+#           startsWith(github.ref, 'refs/heads/test/')


### PR DESCRIPTION
the cipublish and terraform stages of the CI workflow
are not working right now due to a lack of staging
environment, so we're commenting them out for now

## Overview
as a side affect of adding the current version of cipublish in #11, that stage of the github actions pipeline is erroring. The script exists, but the server side of it needs to be configured, so I'm commenting it out until we get to #8 

Brief description of what this PR does, and why it is needed.

Connects #7 

## Testing Instructions

 * ensure that the CI pipeline passes
