### PR TITLE
Enable Static File hosting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - PORT=4545
     volumes:
         - ./src/app:/usr/local/src
-        - ./dist:/usr/local/src/build
+        - ./src/django/static:/usr/local/src/build
         # Ensure node_modules cache doesn't clash with other jobs on CI.
         - /var/cache/iow-boundary-tool-node-modules:/usr/local/src/node_modules
     command: yarn start

--- a/scripts/lint
+++ b/scripts/lint
@@ -23,7 +23,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             scripts/*
 
         # Lint JavaScript
-        # TODO turn this back on when there's javascript to check
         docker-compose \
             run --rm --entrypoint ./node_modules/.bin/eslint \
             app src/ --ext .js --ext .jsx

--- a/scripts/lint
+++ b/scripts/lint
@@ -24,9 +24,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         # Lint JavaScript
         # TODO turn this back on when there's javascript to check
-        # docker-compose \
-        #     run --rm --entrypoint ./node_modules/.bin/eslint \
-        #     app src/ --ext .js --ext .jsx
+        docker-compose \
+            run --rm --entrypoint ./node_modules/.bin/eslint \
+            app src/ --ext .js --ext .jsx
 
         if [[ -n "${CI}" ]]; then
             # Lint Django app

--- a/scripts/update
+++ b/scripts/update
@@ -38,6 +38,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
         # Collect Django static files
         # TODO enable this after static file hosting is corrected
-        # ./scripts/manage collectstatic --no-input
+        ./scripts/manage collectstatic --no-input
     fi
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -37,7 +37,6 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         ./scripts/manage migrate
 
         # Collect Django static files
-        # TODO enable this after static file hosting is corrected
         ./scripts/manage collectstatic --no-input
     fi
 fi

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -211,7 +211,6 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
-# TODO enable static file hosting
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -214,6 +214,7 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATICFILES_DIRS = ((os.path.join(STATIC_ROOT, "static")),)
 
 # From the django-spa README
 # https://github.com/metakermit/django-spa/tree/418fd20e0cf1339ac259d16ce3d6f78c2868d1cd

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -22,9 +22,6 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-# TODO: move this to .env
-
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY", "secret")
 
 ENVIRONMENT = os.getenv("DJANGO_ENV", "Development")
@@ -92,7 +89,7 @@ INSTALLED_APPS = [
     "django.contrib.gis",
     'django.contrib.sessions',
     'django.contrib.messages',
-    # 'django.contrib.staticfiles',
+    'django.contrib.staticfiles',
     'django_extensions',
     "rest_framework",
     "rest_framework_gis",
@@ -216,9 +213,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 # TODO enable static file hosting
 
-# STATIC_URL = '/static/'
-# STATIC_ROOT = os.path.join(BASE_DIR, "static")
-# STATICFILES_DIRS = ((os.path.join(STATIC_ROOT, "static")),)
+STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
 # From the django-spa README
 # https://github.com/metakermit/django-spa/tree/418fd20e0cf1339ac259d16ce3d6f78c2868d1cd

--- a/src/django/iow/urls.py
+++ b/src/django/iow/urls.py
@@ -15,10 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf.urls.static import static
+
+from . import settings
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
     path('health-check/', include('watchman.urls')),
-]
-# ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Cleaning up configuration to enable django hosting static files from the frontend.

## Overview

This PR configures the plugins and configuration necessary for django to host static files for the frontend.

Connects #10 


## Testing Instructions

 * Check out this branch
 * Run `scripts/update`
 * Run `scripts/server`
 * In a web browser, load the [local development site](http://localhost:8181/)
 * If this test is successful, it will load a blank white screen with the title 'React App'. If it is not successful, it will load a "Page not found" 404 error
