### PR TITLE
Fix react-remove-scroll-bar warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix react-remove-scroll-bar warning [#29](https://github.com/azavea/iow-boundary-tool/pull/29)
+
 ### Deprecated
 
 ### Removed

--- a/src/app/src/components/WelcomeModal.js
+++ b/src/app/src/components/WelcomeModal.js
@@ -39,7 +39,14 @@ export default function WelcomeModal() {
     const Section = sections[currentSection];
 
     return (
-        <Modal isOpen isCentered size={'5xl'}>
+        <Modal
+            isOpen
+            isCentered
+            size={'5xl'}
+            // Fix react-remove-scroll-bar warning seen with multiple modals
+            // https://github.com/chakra-ui/chakra-ui/issues/6213
+            blockScrollOnMount={currentSection === firstSection}
+        >
             <ModalOverlay />
             <Section
                 {...{


### PR DESCRIPTION
## Overview

This happens when there are multiple modals and each tries to block scrolling of the parent container, but it has already been blocked by the previous modal.

This makes it so that only the first one does so, preventing the warning from appearing in the console.

For reference see: https://github.com/chakra-ui/chakra-ui/issues/6213#issuecomment-1216003840

Connects #22 

## Testing Instructions

- Check out this branch and `server`
- Go to http://localhost:4545/welcome
- Open the developer tools console
- Go forwards and backwards through the modals
  - [x] Ensure there aren't any warnings in the console

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
