### PR TITLE
Add Redux State Machinery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Welcome page [#25](https://github.com/azavea/iow-boundary-tool/pull/25)
 - Add Sidebar UI [#26](https://github.com/azavea/iow-boundary-tool/pull/26)
 - Add Draw Map UI and base polygon functionality [#30](https://github.com/azavea/iow-boundary-tool/pull/30)
+- Add Redux state [#37](https://github.com/azavea/iow-boundary-tool/pull/37)
 
 ### Changed
 

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -17,6 +17,7 @@
     "@fontsource/inter": "^4.5.12",
     "@fontsource/quicksand": "^4.5.10",
     "@heroicons/react": "^1.0.6",
+    "@reduxjs/toolkit": "^1.8.4",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^14.2.0",
@@ -27,14 +28,13 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.0.1",
+    "react-redux": "^8.0.2",
     "react-router": "^6.3.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
     "react-use": "^17.3.2",
     "redux": "^4.2.0",
-    "redux-act": "^1.8.0",
-    "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.1"
+    "redux-logger": "^3.0.6"
   },
   "scripts": {
     "start": "craco start",

--- a/src/app/src/components/DrawMap/DeletePolygonConfirmModal.js
+++ b/src/app/src/components/DrawMap/DeletePolygonConfirmModal.js
@@ -9,12 +9,11 @@ import {
     Flex,
     Spacer,
 } from '@chakra-ui/react';
+import { useDispatch } from 'react-redux';
+import { deletePolygon } from '../../store/mapSlice';
 
-export default function DeletePolygonConfirmModal({
-    isOpen,
-    onConfirm,
-    onClose,
-}) {
+export default function DeletePolygonConfirmModal({ isOpen, onClose }) {
+    const dispatch = useDispatch();
     const cancelRef = useRef();
 
     return (
@@ -43,7 +42,7 @@ export default function DeletePolygonConfirmModal({
                             <Button
                                 variant='cta'
                                 onClick={() => {
-                                    onConfirm();
+                                    dispatch(deletePolygon());
                                     onClose();
                                 }}
                             >

--- a/src/app/src/components/DrawMap/DrawMap.js
+++ b/src/app/src/components/DrawMap/DrawMap.js
@@ -5,17 +5,17 @@ import { ArrowRightIcon } from '@heroicons/react/outline';
 import Map from '../Map';
 import EditToolbar from './EditToolbar';
 import MapControlButtons from './MapControlButtons';
+import MapFeatures from './MapFeatures';
 
 export default function DrawMap() {
     return (
-        <>
-            <Map>
-                <EditToolbar />
-                <SaveAndBackButton />
-                <ReviewAndSaveButton />
-                <MapControlButtons />
-            </Map>
-        </>
+        <Map>
+            <MapFeatures />
+            <EditToolbar />
+            <SaveAndBackButton />
+            <ReviewAndSaveButton />
+            <MapControlButtons />
+        </Map>
     );
 }
 

--- a/src/app/src/components/DrawMap/EditPolygonModal.js
+++ b/src/app/src/components/DrawMap/EditPolygonModal.js
@@ -13,13 +13,11 @@ import {
     ModalBody,
 } from '@chakra-ui/react';
 import { CloudUploadIcon } from '@heroicons/react/outline';
+import { useDispatch } from 'react-redux';
+import { renamePolygon } from '../../store/mapSlice';
 
-export default function EditPolygonModal({
-    isOpen,
-    defaultLabel,
-    onSubmit,
-    onClose,
-}) {
+export default function EditPolygonModal({ isOpen, defaultLabel, onClose }) {
+    const dispatch = useDispatch();
     const [label, setLabel] = useState(defaultLabel);
 
     useEffect(() => setLabel(defaultLabel), [defaultLabel]);
@@ -51,7 +49,7 @@ export default function EditPolygonModal({
                             <Button
                                 variant='cta'
                                 onClick={() => {
-                                    onSubmit(label);
+                                    dispatch(renamePolygon(label));
                                     onClose();
                                 }}
                             >

--- a/src/app/src/components/DrawMap/MapControlButtons.js
+++ b/src/app/src/components/DrawMap/MapControlButtons.js
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { Box, Icon, IconButton, VStack } from '@chakra-ui/react';
 
 import { SearchIcon, PlusIcon, MinusIcon } from '@heroicons/react/outline';
@@ -33,9 +32,7 @@ export default function MapControlButtons() {
 }
 
 function MapControlButton({ icon, onClick }) {
-    const ref = useRef();
-
-    usePreventMapDoubleClick(ref);
+    const ref = usePreventMapDoubleClick();
 
     return (
         <IconButton

--- a/src/app/src/components/DrawMap/MapFeatures.js
+++ b/src/app/src/components/DrawMap/MapFeatures.js
@@ -1,0 +1,7 @@
+import useEditingPolygon from './useEditingPolygon';
+
+export default function MapFeatures() {
+    useEditingPolygon();
+
+    return null;
+}

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
     Box,
     Button,
@@ -20,14 +19,9 @@ import {
 
 import BasemapDefaultImage from '../img/basemap-default.png';
 import BasemapSatelliteImage from '../img/basemap-satellite.jpg';
-
-const basemapLayers = [
-    'Streets',
-    'Parcel data',
-    'Municipal boundaries',
-    'Land & water',
-    'Points of interest',
-];
+import { useDispatch, useSelector } from 'react-redux';
+import { setBasemapType, toggleLayer } from '../store/mapSlice';
+import { BASE_MAP_LAYERS } from '../constants';
 
 const marginLeft = 4;
 
@@ -76,22 +70,11 @@ function ReferenceLayers() {
 }
 
 function BasemapLayers() {
-    const [satelliteMode, setSatelliteMode] = useState(false);
-    const [visibility, setVisibility] = useState(() =>
-        basemapLayers.reduce(
-            (visibility, layer) => ({
-                ...visibility,
-                [layer]: true,
-            }),
-            {}
-        )
-    );
+    const dispatch = useDispatch();
+    const { layers, basemapType } = useSelector(state => state.map);
 
     const toggleVisibility = layer => {
-        setVisibility(visibility => ({
-            ...visibility,
-            [layer]: !visibility[layer],
-        }));
+        dispatch(toggleLayer(layer));
     };
 
     return (
@@ -100,10 +83,10 @@ function BasemapLayers() {
                 Basemap Layers
             </Heading>
             <Flex direction='column' align='flex-start' mt={4}>
-                {basemapLayers.map(layer => (
+                {BASE_MAP_LAYERS.map(layer => (
                     <VisibilityButton
                         key={layer}
-                        visible={visibility[layer]}
+                        visible={layers.includes(layer)}
                         onChange={() => toggleVisibility(layer)}
                         label={layer}
                     />
@@ -113,14 +96,14 @@ function BasemapLayers() {
                 <ImageButton
                     image={BasemapDefaultImage}
                     label='Default'
-                    selected={!satelliteMode}
-                    onClick={() => setSatelliteMode(false)}
+                    selected={basemapType === 'default'}
+                    onClick={() => dispatch(setBasemapType('default'))}
                 />
                 <ImageButton
                     image={BasemapSatelliteImage}
                     label='Satellite'
-                    selected={satelliteMode}
-                    onClick={() => setSatelliteMode(true)}
+                    selected={basemapType === 'satellite'}
+                    onClick={() => dispatch(setBasemapType('satellite'))}
                 />
             </Flex>
         </Box>

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -1,3 +1,10 @@
 export const MAP_CENTER = [35.7596, -79.0193]; // North Carolina
 export const MAP_INITIAL_ZOOM = 13;
 export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
+export const BASE_MAP_LAYERS = [
+    'Streets',
+    'Parcel data',
+    'Municipal boundaries',
+    'Land & water',
+    'Points of interest',
+];

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export function useDialogController() {
     const [isOpen, setIsOpen] = useState(false);
@@ -13,7 +13,9 @@ export function useDialogController() {
     };
 }
 
-export function usePreventMapDoubleClick(ref) {
+export function usePreventMapDoubleClick() {
+    const ref = useRef();
+
     useEffect(() => {
         if (ref.current) {
             const thisWasClicked = event =>
@@ -38,4 +40,6 @@ export function usePreventMapDoubleClick(ref) {
                 );
         }
     }, [ref]);
+
+    return ref;
 }

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { ChakraProvider } from '@chakra-ui/react';
+import { Provider as ReduxProvider } from 'react-redux';
 
 import '@fontsource/quicksand/700.css';
 import '@fontsource/quicksand/500.css';
@@ -13,13 +14,16 @@ import './index.css';
 import App from './App';
 import theme from './theme';
 import * as serviceWorker from './serviceWorker';
+import store from './store';
 
 const root = createRoot(document.getElementById('root'));
 root.render(
     <React.StrictMode>
-        <ChakraProvider theme={theme}>
-            <App />
-        </ChakraProvider>
+        <ReduxProvider store={store}>
+            <ChakraProvider theme={theme}>
+                <App />
+            </ChakraProvider>
+        </ReduxProvider>
     </React.StrictMode>
 );
 

--- a/src/app/src/store/index.js
+++ b/src/app/src/store/index.js
@@ -1,0 +1,1 @@
+export { default } from './store';

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -1,0 +1,89 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { BASE_MAP_LAYERS } from '../constants';
+
+const initialState = {
+    polygon: null,
+    addPolygonMode: false,
+    editMode: false,
+    layers: BASE_MAP_LAYERS,
+    basemapType: 'default',
+};
+
+const DEFAULT_POLYGON = {
+    points: [],
+    visible: true,
+    label: 'New Polygon',
+};
+
+function checkPolygonIsSet(state) {
+    if (!state.polygon) {
+        throw Error('No polygon saved');
+    }
+}
+
+export const mapSlice = createSlice({
+    name: 'map',
+    initialState,
+    reducers: {
+        addPolygon: (state, { payload: newPolygon }) => {
+            state.polygon = {
+                ...DEFAULT_POLYGON,
+                ...newPolygon,
+            };
+            state.addPolygonMode = false;
+            state.editMode = true;
+        },
+        updatePolygon: (state, { payload: polygonUpdate }) => {
+            checkPolygonIsSet(state);
+
+            state.polygon = {
+                ...state.polygon,
+                ...polygonUpdate,
+            };
+        },
+        deletePolygon: state => {
+            state.polygon = null;
+        },
+        togglePolygonVisibility: state => {
+            checkPolygonIsSet(state);
+
+            state.polygon.visible = !state.polygon.visible;
+        },
+        renamePolygon: (state, { payload: newLabel }) => {
+            checkPolygonIsSet(state);
+
+            state.polygon.label = newLabel;
+        },
+        startAddPolygon: state => {
+            state.addPolygonMode = true;
+        },
+        toggleEditMode: state => {
+            state.editMode = !state.editMode;
+        },
+        toggleLayer: (state, { payload: layerToToggle }) => {
+            if (state.layers.includes(layerToToggle)) {
+                state.layers = state.layers.filter(
+                    layer => layer !== layerToToggle
+                );
+            } else {
+                state.layers.push(layerToToggle);
+            }
+        },
+        setBasemapType: (state, { payload: basemapType }) => {
+            state.basemapType = basemapType;
+        },
+    },
+});
+
+export const {
+    addPolygon,
+    updatePolygon,
+    deletePolygon,
+    togglePolygonVisibility,
+    renamePolygon,
+    toggleEditMode,
+    toggleLayer,
+    setBasemapType,
+} = mapSlice.actions;
+
+export default mapSlice.reducer;

--- a/src/app/src/store/store.js
+++ b/src/app/src/store/store.js
@@ -1,0 +1,9 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import mapReducer from './mapSlice';
+
+export default configureStore({
+    reducer: {
+        map: mapReducer,
+    },
+});

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -1,5 +1,7 @@
 import { Icon } from '@chakra-ui/react';
 
+import { INITIAL_POLYGON_SCALE_FACTOR } from './constants';
+
 export function heroToChakraIcon(icon) {
     return function ConvertedIcon() {
         return <Icon as={icon} />;
@@ -13,4 +15,22 @@ export function convertIndexedObjectToArray(obj) {
     }
 
     return array;
+}
+
+export function generateDefaultRectangle({ bounds, center }) {
+    const west = scaleRange(center.lng, bounds.getWest());
+    const east = scaleRange(center.lng, bounds.getEast());
+    const north = scaleRange(center.lat, bounds.getNorth());
+    const south = scaleRange(center.lat, bounds.getSouth());
+
+    return [
+        [north, west],
+        [north, east],
+        [south, east],
+        [south, west],
+    ];
+}
+
+function scaleRange(center, limit) {
+    return center + INITIAL_POLYGON_SCALE_FACTOR * (limit - center);
 }

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -2000,7 +2000,7 @@
     core-js-pure "^3.15.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.18.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.18.3":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
   integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
@@ -3352,6 +3352,16 @@
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-2.0.0.tgz#212f4d87dc7681f40ca0e47d99672676c20c8ef6"
   integrity sha512-SQQ5DCQIaLzvslN6wCXs5OWqtlvk1Ubv2n5d7zTM8SDl9hM5Rr2wVy7/nOCIY958D75/ovhq6ZoSvT7GLCX6sg==
 
+"@reduxjs/toolkit@^1.8.4":
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.4.tgz#8f226acff22adf539d078b64fa2eafc3f8d1d045"
+  integrity sha512-IpFq1WI7sCYeLQpDCGvlcQY9wn70UpAM3cOLq78HRnVn1746RI+l3y5xcuOeVOxORaxABJh3cfJMxycD2IwH5w==
+  dependencies:
+    immer "^9.0.7"
+    redux "^4.1.2"
+    redux-thunk "^2.4.1"
+    reselect "^4.1.5"
+
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"
@@ -3755,6 +3765,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^6.0.0":
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
@@ -3936,6 +3954,11 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
+
+"@types/use-sync-external-store@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz#b6725d5f4af24ace33b36fafd295136e75509f43"
+  integrity sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==
 
 "@types/ws@^8.5.1":
   version "8.5.3"
@@ -7025,7 +7048,7 @@ history@^5.2.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -9997,6 +10020,18 @@ react-leaflet@^4.0.1:
   dependencies:
     "@react-leaflet/core" "^2.0.0"
 
+react-redux@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-8.0.2.tgz#bc2a304bb21e79c6808e3e47c50fe1caf62f7aad"
+  integrity sha512-nBwiscMw3NoP59NFCXFf02f8xdo+vSHT/uZ1ldDwF7XaTpzm+Phk97VT4urYBl5TYAPNVaFm12UHAEyzkpNzRA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/hoist-non-react-statics" "^3.3.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    hoist-non-react-statics "^3.3.2"
+    react-is "^18.0.0"
+    use-sync-external-store "^1.0.0"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -10176,11 +10211,6 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux-act@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/redux-act/-/redux-act-1.8.0.tgz#5394a9433b36937d1a1da11aca6547d97d10ab00"
-  integrity sha512-xW3FIco/VwJGMW3eCD3JGAxyozNC4k35qrWM5lEQf9T2pfv3leDC+3vQ8WdHZjcrol/jjWAeJ+ULqrscuDqlKg==
-
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -10193,7 +10223,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.2.0:
+redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==
@@ -10358,6 +10388,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.1.5:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.6.tgz#19ca2d3d0b35373a74dc1c98692cdaffb6602656"
+  integrity sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
@@ -11591,6 +11626,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Overview

This PR adds state in the form of a Redux store. It uses two addition libraries from the Redux team:
- [`react-redux`](https://react-redux.js.org/) for the `useSelector` and `useDispatch` hooks
- [`@reduxjs/toolkit`](https://redux-toolkit.js.org/) for `createSlice`

Closes #27 

## Testing Instructions

- The welcome page is unchanged
- On the draw page:
  - The sidebar elements should toggle as expected
  - Polygon drawing should still work and should persist among other actions (toggle visibility/edit mode)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
