### PR TITLE
Add Add Polygon Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Draw Map UI and base polygon functionality [#30](https://github.com/azavea/iow-boundary-tool/pull/30)
 - Add Redux state [#37](https://github.com/azavea/iow-boundary-tool/pull/37)
 - Add transition to draw page [#43](https://github.com/azavea/iow-boundary-tool/pull/43)
+- Add user polygon start location feature [#38](https://github.com/azavea/iow-boundary-tool/pull/38)
 
 ### Changed
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -17,3 +17,7 @@
 .leaflet-overlay-pane g path.leaflet-interactive {
     cursor: inherit;
 }
+
+.leaflet-container.crosshair-cursor-enabled {
+    cursor: crosshair;
+}

--- a/src/app/src/components/DrawMap/EditToolbar.js
+++ b/src/app/src/components/DrawMap/EditToolbar.js
@@ -17,23 +17,25 @@ import {
     PencilIcon,
 } from '@heroicons/react/outline';
 import { CursorClickIcon } from '@heroicons/react/solid';
-import { useMap } from 'react-leaflet';
 
 import AddPolygonIcon from '../../img/AddPolygonIcon.js';
 import DeletePolygonConfirmModal from './DeletePolygonConfirmModal.js';
 import { useDialogController } from '../../hooks.js';
 import EditPolygonModal from './EditPolygonModal.js';
 import {
-    addPolygon,
+    cancelAddPolygon,
+    startAddPolygon,
     toggleEditMode,
     togglePolygonVisibility,
 } from '../../store/mapSlice.js';
-import { generateDefaultRectangle } from '../../utils.js';
+
+const POLYGON_BUTTON_WIDTH = 40;
 
 export default function EditToolbar() {
     const dispatch = useDispatch();
-    const map = useMap();
-    const { polygon, editMode } = useSelector(state => state.map);
+    const { polygon, editMode, addPolygonMode } = useSelector(
+        state => state.map
+    );
 
     const confirmDeleteDialogController = useDialogController();
     const editDialogController = useDialogController();
@@ -51,29 +53,30 @@ export default function EditToolbar() {
                 borderColor='gray.50'
                 borderRadius='6px'
                 boxShadow='lg'
+                cursor='default'
             >
                 <Flex>
-                    {polygon ? (
+                    {addPolygonMode ? (
+                        <Button
+                            onClick={() => dispatch(cancelAddPolygon())}
+                            w={POLYGON_BUTTON_WIDTH}
+                        >
+                            Cancel
+                        </Button>
+                    ) : polygon ? (
                         <Button
                             onClick={editDialogController.open}
                             rightIcon={<Icon as={PencilIcon} />}
                             variant='toolbar'
+                            minW={POLYGON_BUTTON_WIDTH}
                         >
                             {polygon.label}
                         </Button>
                     ) : (
                         <Button
-                            onClick={() =>
-                                dispatch(
-                                    addPolygon({
-                                        points: generateDefaultRectangle({
-                                            bounds: map.getBounds(),
-                                            center: map.getCenter(),
-                                        }),
-                                    })
-                                )
-                            }
+                            onClick={() => dispatch(startAddPolygon())}
                             rightIcon={<AddPolygonIcon />}
+                            w={POLYGON_BUTTON_WIDTH}
                         >
                             Draw Polygon
                         </Button>

--- a/src/app/src/components/DrawMap/MapFeatures.js
+++ b/src/app/src/components/DrawMap/MapFeatures.js
@@ -1,7 +1,9 @@
+import useAddPolygonCursor from './useAddPolygonCursor';
 import useEditingPolygon from './useEditingPolygon';
 
 export default function MapFeatures() {
     useEditingPolygon();
+    useAddPolygonCursor();
 
     return null;
 }

--- a/src/app/src/components/DrawMap/useAddPolygonCursor.js
+++ b/src/app/src/components/DrawMap/useAddPolygonCursor.js
@@ -1,0 +1,45 @@
+import { useCallback, useEffect } from 'react';
+import { useMap } from 'react-leaflet';
+import { useDispatch, useSelector } from 'react-redux';
+import { DomUtil } from 'leaflet';
+
+import { addPolygon } from '../../store/mapSlice';
+import { generateInitialPolygonPoints } from '../../utils';
+
+export default function useAddPolygonCursor() {
+    const map = useMap();
+    const dispatch = useDispatch();
+    const addPolygonMode = useSelector(state => state.map.addPolygonMode);
+
+    const addPolygonFromEvent = useCallback(
+        event => {
+            if (event.originalEvent.target !== map._container) {
+                // Ignore UI element clicks
+                return;
+            }
+
+            map.flyTo(event.latlng);
+            dispatch(
+                addPolygon({
+                    points: generateInitialPolygonPoints({
+                        mapBounds: map.getBounds(),
+                        center: event.latlng,
+                    }),
+                })
+            );
+        },
+        [map, dispatch]
+    );
+
+    useEffect(() => {
+        if (addPolygonMode) {
+            DomUtil.addClass(map._container, 'crosshair-cursor-enabled');
+            map.on('click', addPolygonFromEvent);
+
+            return () => {
+                DomUtil.removeClass(map._container, 'crosshair-cursor-enabled');
+                map.off('click', addPolygonFromEvent);
+            };
+        }
+    }, [map, addPolygonMode, addPolygonFromEvent]);
+}

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -57,6 +57,9 @@ export const mapSlice = createSlice({
         startAddPolygon: state => {
             state.addPolygonMode = true;
         },
+        cancelAddPolygon: state => {
+            state.addPolygonMode = false;
+        },
         toggleEditMode: state => {
             state.editMode = !state.editMode;
         },
@@ -81,6 +84,8 @@ export const {
     deletePolygon,
     togglePolygonVisibility,
     renamePolygon,
+    startAddPolygon,
+    cancelAddPolygon,
     toggleEditMode,
     toggleLayer,
     setBasemapType,

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -17,20 +17,29 @@ export function convertIndexedObjectToArray(obj) {
     return array;
 }
 
-export function generateDefaultRectangle({ bounds, center }) {
-    const west = scaleRange(center.lng, bounds.getWest());
-    const east = scaleRange(center.lng, bounds.getEast());
-    const north = scaleRange(center.lat, bounds.getNorth());
-    const south = scaleRange(center.lat, bounds.getSouth());
+export function generateInitialPolygonPoints({ mapBounds, center }) {
+    const polygonBounds = center.toBounds(
+        getSmallestBoundsDimension(mapBounds) * INITIAL_POLYGON_SCALE_FACTOR
+    );
+
+    const northWest = polygonBounds.getNorthWest();
+    const northEast = polygonBounds.getNorthEast();
+    const southEast = polygonBounds.getSouthEast();
+    const southWest = polygonBounds.getSouthWest();
 
     return [
-        [north, west],
-        [north, east],
-        [south, east],
-        [south, west],
+        [northWest.lat, northWest.lng],
+        [northEast.lat, northEast.lng],
+        [southEast.lat, southEast.lng],
+        [southWest.lat, southWest.lng],
     ];
 }
 
-function scaleRange(center, limit) {
-    return center + INITIAL_POLYGON_SCALE_FACTOR * (limit - center);
+function getSmallestBoundsDimension(bounds) {
+    const northWidth = bounds.getNorthWest().distanceTo(bounds.getNorthEast());
+    const southWidth = bounds.getSouthWest().distanceTo(bounds.getSouthEast());
+    const westHeight = bounds.getNorthWest().distanceTo(bounds.getSouthWest());
+    const eastHeight = bounds.getNorthEast().distanceTo(bounds.getSouthEast());
+
+    return Math.min(northWidth, southWidth, westHeight, eastHeight);
 }


### PR DESCRIPTION
## Overview

This PR adds functionality that allows the user to determine where the initial rectangle should appear when starting a polygon.

Closes #35 

### Notes

This PR also changes how the initial rectangle is calculated:
- First the length of the smallest dimension of the map bounds is determined.
- This length is then used to create a new bounds centered on the user click location
- The corners of this new bound become the corners of the initial rectangle.

## Testing Instructions

- Go to map draw page
- Click "Draw Polygon"
- Click somewhere on the map and see that the map pans there and the new polygon is centered there.
- Also try clicking "Cancel" after "Draw Polygon" to make sure the user can back out of Add Polygon Mode

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
