### PR TITLE
Add transition to draw page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Sidebar UI [#26](https://github.com/azavea/iow-boundary-tool/pull/26)
 - Add Draw Map UI and base polygon functionality [#30](https://github.com/azavea/iow-boundary-tool/pull/30)
 - Add Redux state [#37](https://github.com/azavea/iow-boundary-tool/pull/37)
+- Add transition to draw page [#43](https://github.com/azavea/iow-boundary-tool/pull/43)
 
 ### Changed
 

--- a/src/app/src/components/ModalSections/FileUpload.js
+++ b/src/app/src/components/ModalSections/FileUpload.js
@@ -10,12 +10,15 @@ import {
     Progress,
     Text,
 } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import { CloudUploadIcon } from '@heroicons/react/outline';
 
 import { convertIndexedObjectToArray } from '../../utils';
 import ModalSection from './ModalSection';
 
-export default function FileUpload({ PreviousButton, ContinueButton }) {
+export default function FileUpload({ PreviousButton }) {
+    const navigate = useNavigate();
+
     const [files, setFiles] = useState([]);
 
     const addFiles = newFiles => setFiles(files => [...files, ...newFiles]);
@@ -25,7 +28,11 @@ export default function FileUpload({ PreviousButton, ContinueButton }) {
             preHeading='Optional'
             heading='Would you like to add your current map?'
             prevButton={PreviousButton}
-            nextButton={ContinueButton}
+            nextButton={
+                <Button variant='cta' onClick={() => navigate('/draw')}>
+                    Continue
+                </Button>
+            }
         >
             <Text>
                 If you would like to look at a reference or start from an


### PR DESCRIPTION
## Overview

This PR connects the last section of the welcome model to the draw page.

Closes #41 

## Testing Instructions

- Go to welcome page
- Step through sections
- On the last section, clicking continue should take you to the draw page
- Hitting the browser back button should take you back to the welcome page

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
