### PR TITLE
Add Parcel Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add satellite basemap [#39](https://github.com/azavea/iow-boundary-tool/pull/39)
 - Add municipal boundaries data layer [#40](https://github.com/azavea/iow-boundary-tool/pull/40)
 - Add geocoder [#44](https://github.com/azavea/iow-boundary-tool/pull/44)
+- Add Parcel Layer [#50](https://github.com/azavea/iow-boundary-tool/pull/50)
 
 ### Changed
 

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -22,6 +22,7 @@
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^14.2.0",
     "axios": "^0.27.2",
+    "esri-leaflet": "^3.0.8",
     "framer-motion": "^6",
     "leaflet": "^1.8.0",
     "leaflet-draw": "^1.0.4",

--- a/src/app/src/components/DrawMap/DrawMap.js
+++ b/src/app/src/components/DrawMap/DrawMap.js
@@ -9,12 +9,14 @@ import MapFeatures from './MapFeatures';
 
 import { DefaultBasemap, SatelliteBasemap } from '../Layers/Basemaps';
 import MunicipalBoundariesLayer from '../Layers/MunicipalBoundariesLayer';
+import ParcelLayer from '../Layers/ParcelLayer';
 
 export default function DrawMap() {
     return (
         <Map>
             <Basemap />
             <MunicipalBoundariesLayer />
+            <ParcelLayer />
             <MapFeatures />
             <EditToolbar />
             <SaveAndBackButton />

--- a/src/app/src/components/DrawMap/MapFeatures.js
+++ b/src/app/src/components/DrawMap/MapFeatures.js
@@ -1,11 +1,13 @@
 import useAddPolygonCursor from './useAddPolygonCursor';
 import useEditingPolygon from './useEditingPolygon';
 import useGeocoderResult from './useGeocoderResult';
+import useTrackMapZoom from './useTrackMapZoom';
 
 export default function MapFeatures() {
     useEditingPolygon();
     useAddPolygonCursor();
     useGeocoderResult();
+    useTrackMapZoom();
 
     return null;
 }

--- a/src/app/src/components/DrawMap/useTrackMapZoom.js
+++ b/src/app/src/components/DrawMap/useTrackMapZoom.js
@@ -1,0 +1,12 @@
+import { useMapEvent } from 'react-leaflet';
+import { useDispatch } from 'react-redux';
+
+import { setMapZoom } from '../../store/mapSlice';
+
+export default function useTrackMapZoom() {
+    const dispatch = useDispatch();
+
+    const mapEvents = useMapEvent('zoomend', () => {
+        dispatch(setMapZoom(mapEvents.getZoom()));
+    });
+}

--- a/src/app/src/components/Layers/MunicipalBoundariesLayer.js
+++ b/src/app/src/components/Layers/MunicipalBoundariesLayer.js
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
 import L from 'leaflet';
 
-import { useMapLayer } from '../../hooks';
+import { useLayerVisibility, useMapLayer } from '../../hooks';
 
 const MUNICIPAL_BOUNDARIES_LAYER_STYLE = {
     color: 'purple',
@@ -12,11 +11,7 @@ const MUNICIPAL_BOUNDARIES_LAYER_STYLE = {
 };
 
 export default function MunicipalBoundariesLayer() {
-    const layers = useSelector(state => state.map.layers);
-    const showLayer = useMemo(
-        () => layers.includes('MUNICIPAL_BOUNDARIES'),
-        [layers]
-    );
+    const showLayer = useLayerVisibility('MUNICIPAL_BOUNDARIES');
 
     const [layerData, setLayerData] = useState({
         type: 'FeatureCollection',

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -6,29 +6,48 @@ import { DynamicMapLayer } from 'esri-leaflet';
 import { useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
 
-const PARCELS_LAYER_STYLE = {
-    id: 1,
-    source: {
-        type: 'mapLayer',
-        mapLayerId: 1,
-    },
-    drawingInfo: {
-        renderer: {
-            type: 'simple',
-            symbol: {
-                type: 'esriSFS',
-                style: 'esriSFSSolid',
-                color: [0, 0, 0, 0], // No fill
-                outline: {
-                    type: 'esriSLS',
-                    style: 'esriSLSSolid',
+const PARCELS_LAYER_STYLE = [
+    {
+        id: 0,
+        source: {
+            type: 'mapLayer',
+            mapLayerId: 0,
+        },
+        drawingInfo: {
+            renderer: {
+                type: 'simple',
+                symbol: {
+                    type: 'esriSMS',
+                    style: 'esriSMSDiamond',
                     color: [183, 121, 31, 255], // var(--chakra-colors-yellow-600)
-                    width: 1.0,
                 },
             },
         },
     },
-};
+    {
+        id: 1,
+        source: {
+            type: 'mapLayer',
+            mapLayerId: 1,
+        },
+        drawingInfo: {
+            renderer: {
+                type: 'simple',
+                symbol: {
+                    type: 'esriSFS',
+                    style: 'esriSFSSolid',
+                    color: [0, 0, 0, 0], // No fill
+                    outline: {
+                        type: 'esriSLS',
+                        style: 'esriSLSSolid',
+                        color: [183, 121, 31, 255], // var(--chakra-colors-yellow-600)
+                        width: 1.0,
+                    },
+                },
+            },
+        },
+    },
+];
 
 export default function ParcelLayer() {
     const layers = useSelector(state => state.map.layers);
@@ -44,7 +63,7 @@ function RenderEsriLayer() {
             f: 'image',
             layers: [0, 1],
             minZoom: DATA_LAYERS['PARCELS'].minZoom, // Only enable on high zooms for performance
-            dynamicLayers: JSON.stringify([PARCELS_LAYER_STYLE]),
+            dynamicLayers: JSON.stringify(PARCELS_LAYER_STYLE),
         })
     );
 }

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -1,9 +1,6 @@
-import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-
 import { DynamicMapLayer } from 'esri-leaflet';
 
-import { useMapLayer } from '../../hooks';
+import { useLayerVisibility, useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
 
 const PARCELS_LAYER_STYLE = [
@@ -50,8 +47,7 @@ const PARCELS_LAYER_STYLE = [
 ];
 
 export default function ParcelLayer() {
-    const layers = useSelector(state => state.map.layers);
-    const showLayer = useMemo(() => layers.includes('PARCELS'), [layers]);
+    const showLayer = useLayerVisibility('PARCELS');
 
     return showLayer ? <RenderEsriLayer /> : null;
 }

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import { FeatureLayer } from 'esri-leaflet';
+
+import { useMapLayer } from '../../hooks';
+import { PARCELS_LAYER_URL } from '../../constants';
+
+export default function ParcelLayer() {
+    const layers = useSelector(state => state.map.layers);
+    const showLayer = useMemo(() => layers.includes('PARCELS'), [layers]);
+
+    return showLayer ? <RenderEsriLayer /> : null;
+}
+
+function RenderEsriLayer() {
+    useMapLayer(
+        new FeatureLayer({
+            url: PARCELS_LAYER_URL,
+            minZoom: 14,
+        })
+    );
+}

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { FeatureLayer } from 'esri-leaflet';
 
 import { useMapLayer } from '../../hooks';
-import { PARCELS_LAYER_URL } from '../../constants';
+import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
 
 const PARCELS_LAYER_STYLE = {
     color: 'var(--chakra-colors-yellow-600)',
@@ -23,7 +23,7 @@ function RenderEsriLayer() {
     useMapLayer(
         new FeatureLayer({
             url: PARCELS_LAYER_URL,
-            minZoom: 16, // Only enable on high zooms for performance
+            minZoom: DATA_LAYERS['PARCELS'].minZoom, // Only enable on high zooms for performance
             style: PARCELS_LAYER_STYLE,
             simplifyFactor: 0.8, // Simplify parcel shapes for performance
             fields: ['OBJECTID'], // Only fetch smallest field for performance

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -6,6 +6,12 @@ import { FeatureLayer } from 'esri-leaflet';
 import { useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL } from '../../constants';
 
+const PARCELS_LAYER_STYLE = {
+    color: 'var(--chakra-colors-yellow-600)',
+    weight: 1,
+    fill: false,
+};
+
 export default function ParcelLayer() {
     const layers = useSelector(state => state.map.layers);
     const showLayer = useMemo(() => layers.includes('PARCELS'), [layers]);
@@ -17,7 +23,10 @@ function RenderEsriLayer() {
     useMapLayer(
         new FeatureLayer({
             url: PARCELS_LAYER_URL,
-            minZoom: 14,
+            minZoom: 16, // Only enable on high zooms for performance
+            style: PARCELS_LAYER_STYLE,
+            simplifyFactor: 0.8, // Simplify parcel shapes for performance
+            fields: ['OBJECTID'], // Only fetch smallest field for performance
         })
     );
 }

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -3,48 +3,29 @@ import { DynamicMapLayer } from 'esri-leaflet';
 import { useLayerVisibility, useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
 
-const PARCELS_LAYER_STYLE = [
-    {
-        id: 0,
-        source: {
-            type: 'mapLayer',
-            mapLayerId: 0,
-        },
-        drawingInfo: {
-            renderer: {
-                type: 'simple',
-                symbol: {
-                    type: 'esriSMS',
-                    style: 'esriSMSDiamond',
+const PARCELS_LAYER_STYLE = {
+    id: 1,
+    source: {
+        type: 'mapLayer',
+        mapLayerId: 1,
+    },
+    drawingInfo: {
+        renderer: {
+            type: 'simple',
+            symbol: {
+                type: 'esriSFS',
+                style: 'esriSFSSolid',
+                color: [0, 0, 0, 0], // No fill
+                outline: {
+                    type: 'esriSLS',
+                    style: 'esriSLSSolid',
                     color: [183, 121, 31, 255], // var(--chakra-colors-yellow-600)
+                    width: 1.0,
                 },
             },
         },
     },
-    {
-        id: 1,
-        source: {
-            type: 'mapLayer',
-            mapLayerId: 1,
-        },
-        drawingInfo: {
-            renderer: {
-                type: 'simple',
-                symbol: {
-                    type: 'esriSFS',
-                    style: 'esriSFSSolid',
-                    color: [0, 0, 0, 0], // No fill
-                    outline: {
-                        type: 'esriSLS',
-                        style: 'esriSLSSolid',
-                        color: [183, 121, 31, 255], // var(--chakra-colors-yellow-600)
-                        width: 1.0,
-                    },
-                },
-            },
-        },
-    },
-];
+};
 
 export default function ParcelLayer() {
     const showLayer = useLayerVisibility('PARCELS');
@@ -59,7 +40,7 @@ function RenderEsriLayer() {
             f: 'image',
             layers: [0, 1],
             minZoom: DATA_LAYERS['PARCELS'].minZoom, // Only enable on high zooms for performance
-            dynamicLayers: JSON.stringify(PARCELS_LAYER_STYLE),
+            dynamicLayers: JSON.stringify([PARCELS_LAYER_STYLE]),
         })
     );
 }

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -1,16 +1,10 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
-import { FeatureLayer } from 'esri-leaflet';
+import { DynamicMapLayer } from 'esri-leaflet';
 
 import { useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
-
-const PARCELS_LAYER_STYLE = {
-    color: 'var(--chakra-colors-yellow-600)',
-    weight: 1,
-    fill: false,
-};
 
 export default function ParcelLayer() {
     const layers = useSelector(state => state.map.layers);
@@ -21,12 +15,11 @@ export default function ParcelLayer() {
 
 function RenderEsriLayer() {
     useMapLayer(
-        new FeatureLayer({
+        new DynamicMapLayer({
             url: PARCELS_LAYER_URL,
+            f: 'image',
+            layers: [0, 1],
             minZoom: DATA_LAYERS['PARCELS'].minZoom, // Only enable on high zooms for performance
-            style: PARCELS_LAYER_STYLE,
-            simplifyFactor: 0.8, // Simplify parcel shapes for performance
-            fields: ['OBJECTID'], // Only fetch smallest field for performance
         })
     );
 }

--- a/src/app/src/components/Layers/ParcelLayer.js
+++ b/src/app/src/components/Layers/ParcelLayer.js
@@ -6,6 +6,30 @@ import { DynamicMapLayer } from 'esri-leaflet';
 import { useMapLayer } from '../../hooks';
 import { PARCELS_LAYER_URL, DATA_LAYERS } from '../../constants';
 
+const PARCELS_LAYER_STYLE = {
+    id: 1,
+    source: {
+        type: 'mapLayer',
+        mapLayerId: 1,
+    },
+    drawingInfo: {
+        renderer: {
+            type: 'simple',
+            symbol: {
+                type: 'esriSFS',
+                style: 'esriSFSSolid',
+                color: [0, 0, 0, 0], // No fill
+                outline: {
+                    type: 'esriSLS',
+                    style: 'esriSLSSolid',
+                    color: [183, 121, 31, 255], // var(--chakra-colors-yellow-600)
+                    width: 1.0,
+                },
+            },
+        },
+    },
+};
+
 export default function ParcelLayer() {
     const layers = useSelector(state => state.map.layers);
     const showLayer = useMemo(() => layers.includes('PARCELS'), [layers]);
@@ -20,6 +44,7 @@ function RenderEsriLayer() {
             f: 'image',
             layers: [0, 1],
             minZoom: DATA_LAYERS['PARCELS'].minZoom, // Only enable on high zooms for performance
+            dynamicLayers: JSON.stringify([PARCELS_LAYER_STYLE]),
         })
     );
 }

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -71,7 +71,7 @@ function ReferenceLayers() {
 
 function BasemapLayers() {
     const dispatch = useDispatch();
-    const { layers, basemapType } = useSelector(state => state.map);
+    const { layers, basemapType, mapZoom } = useSelector(state => state.map);
 
     const toggleVisibility = layer => {
         dispatch(toggleLayer(layer));
@@ -83,14 +83,17 @@ function BasemapLayers() {
                 Basemap Layers
             </Heading>
             <Flex direction='column' align='flex-start' mt={4}>
-                {Object.entries(DATA_LAYERS).map(([layer, label]) => (
-                    <VisibilityButton
-                        key={layer}
-                        visible={layers.includes(layer)}
-                        onChange={() => toggleVisibility(layer)}
-                        label={label}
-                    />
-                ))}
+                {Object.entries(DATA_LAYERS).map(
+                    ([layer, { label, minZoom }]) => (
+                        <VisibilityButton
+                            key={layer}
+                            visible={layers.includes(layer)}
+                            onChange={() => toggleVisibility(layer)}
+                            label={label}
+                            disabled={!!minZoom && mapZoom < minZoom}
+                        />
+                    )
+                )}
             </Flex>
             <Flex mt={2}>
                 <ImageButton
@@ -110,7 +113,7 @@ function BasemapLayers() {
     );
 }
 
-function VisibilityButton({ label, visible, onChange }) {
+function VisibilityButton({ label, visible, onChange, disabled = false }) {
     return (
         <Button
             mb={1}
@@ -133,6 +136,7 @@ function VisibilityButton({ label, visible, onChange }) {
             color={visible ? 'gray.300' : 'gray.500'}
             textDecoration='none'
             fontWeight={600}
+            disabled={disabled}
         >
             {label}
         </Button>

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -4,7 +4,7 @@ export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
 
 export const DATA_LAYERS = {
     STREETS: { label: 'Streets' },
-    PARCELS: { label: 'Parcel data', minZoom: 13 },
+    PARCELS: { label: 'Parcel data', minZoom: 14 },
     MUNICIPAL_BOUNDARIES: { label: 'Municipal boundaries' },
     LAND_AND_WATER: { label: 'Land & water' },
     POINTS_OF_INTEREST: { label: 'Points of interest' },

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -4,7 +4,7 @@ export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
 
 export const DATA_LAYERS = {
     STREETS: { label: 'Streets' },
-    PARCELS: { label: 'Parcel data', minZoom: 14 },
+    PARCELS: { label: 'Parcel data', minZoom: 13 },
     MUNICIPAL_BOUNDARIES: { label: 'Municipal boundaries' },
     LAND_AND_WATER: { label: 'Land & water' },
     POINTS_OF_INTEREST: { label: 'Points of interest' },

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -22,3 +22,6 @@ export const NC_WEST = -84.321782;
 export const NC_EAST = -75.459815;
 export const NC_NORTH = 36.588133;
 export const NC_SOUTH = 33.851169;
+
+export const PARCELS_LAYER_URL =
+    'https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/FeatureServer/1';

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -4,7 +4,7 @@ export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
 
 export const DATA_LAYERS = {
     STREETS: { label: 'Streets' },
-    PARCELS: { label: 'Parcel data', minZoom: 16 },
+    PARCELS: { label: 'Parcel data', minZoom: 14 },
     MUNICIPAL_BOUNDARIES: { label: 'Municipal boundaries' },
     LAND_AND_WATER: { label: 'Land & water' },
     POINTS_OF_INTEREST: { label: 'Points of interest' },
@@ -24,4 +24,4 @@ export const NC_NORTH = 36.588133;
 export const NC_SOUTH = 33.851169;
 
 export const PARCELS_LAYER_URL =
-    'https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/FeatureServer/1';
+    'https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/MapServer';

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -3,11 +3,11 @@ export const MAP_INITIAL_ZOOM = 13;
 export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
 
 export const DATA_LAYERS = {
-    STREETS: 'Streets',
-    PARCELS: 'Parcel data',
-    MUNICIPAL_BOUNDARIES: 'Municipal boundaries',
-    LAND_AND_WATER: 'Land & water',
-    POINTS_OF_INTEREST: 'Points of interest',
+    STREETS: { label: 'Streets' },
+    PARCELS: { label: 'Parcel data', minZoom: 16 },
+    MUNICIPAL_BOUNDARIES: { label: 'Municipal boundaries' },
+    LAND_AND_WATER: { label: 'Land & water' },
+    POINTS_OF_INTEREST: { label: 'Points of interest' },
 };
 
 export const ESRI_ATTRIBUTION =

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMap } from 'react-leaflet';
+import { useSelector } from 'react-redux';
 
 export function useDialogController() {
     const [isOpen, setIsOpen] = useState(false);
@@ -65,4 +66,8 @@ export function useMapLayer(layer) {
             }
         };
     }, [map, layer]);
+}
+
+export function useLayerVisibility(layer) {
+    return useSelector(state => state.map.layers).includes(layer);
 }

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { DATA_LAYERS } from '../constants';
+import { DATA_LAYERS, MAP_INITIAL_ZOOM } from '../constants';
 
 const initialState = {
     polygon: null,
@@ -8,6 +8,7 @@ const initialState = {
     layers: Object.keys(DATA_LAYERS),
     basemapType: 'default',
     geocodeResult: null,
+    mapZoom: MAP_INITIAL_ZOOM,
 };
 
 const DEFAULT_POLYGON = {
@@ -82,6 +83,9 @@ export const mapSlice = createSlice({
         clearGeocodeResult: state => {
             state.geocodeResult = null;
         },
+        setMapZoom: (state, { payload: mapZoom }) => {
+            state.mapZoom = mapZoom;
+        },
     },
 });
 
@@ -98,6 +102,7 @@ export const {
     setBasemapType,
     setGeocodeResult,
     clearGeocodeResult,
+    setMapZoom,
 } = mapSlice.actions;
 
 export default mapSlice.reducer;

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -3536,6 +3536,18 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@terraformer/arcgis@^2.1.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/arcgis/-/arcgis-2.1.2.tgz#9e05cc5e0ddc400e532f6ccb1d91bdf420e4a756"
+  integrity sha512-IvdfqehcNAUtKU1OFMKwPT8EvdKlVFZ7q7ZKzkIF8XzYZIVsZLuXuOS1UBdRh5u/o+X5Gax7jiZhD8U/4TV+Jw==
+  dependencies:
+    "@terraformer/common" "^2.1.2"
+
+"@terraformer/common@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@terraformer/common/-/common-2.1.2.tgz#7bf83f81f1c3a99069c714c044004f9707f00c97"
+  integrity sha512-cwPdTFzIpekZhZRrgDEkqLKNPoqbyCBQHiemaovnGIeUx0Pl336MY/eCxzJ5zXkrQLVo9zPalq/vYW5HnyKevQ==
+
 "@testing-library/dom@^8.5.0":
   version "8.13.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.13.0.tgz#bc00bdd64c7d8b40841e27a70211399ad3af46f5"
@@ -6388,6 +6400,14 @@ esrecurse@^4.3.0:
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
+
+esri-leaflet@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/esri-leaflet/-/esri-leaflet-3.0.8.tgz#040aae75226992521ca19abc7b837213e9a7512c"
+  integrity sha512-mLb4pRfDAbkG1YhuajD22erLXIAtrF1R32hmgmlJNI3t47n6KjTppCb8lViia0O7+GDORXFuJ9Lj9RkpsaKhSA==
+  dependencies:
+    "@terraformer/arcgis" "^2.1.0"
+    tiny-binary-search "^1.0.3"
 
 estraverse@^4.1.1:
   version "4.3.0"
@@ -11326,6 +11346,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+tiny-binary-search@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-binary-search/-/tiny-binary-search-1.0.3.tgz#9d52e3d16dd1171eb74486caf704ba08c0c62186"
+  integrity sha512-STSHX/L5nI9WTLv6wrzJbAPbO7OIISX83KFBh2GVbX1Uz/vgZOU/ANn/8iV6t35yMTpoPzzO+3OQid3mifE0CA==
 
 tiny-invariant@^1.0.6:
   version "1.2.0"


### PR DESCRIPTION
## Overview

Adds Parcel Layer via the NC One Map ArcGIS API.

Closes #33 

### Demo

~~https://user-images.githubusercontent.com/1430060/187294794-54343556-8989-4515-a6cd-8ca3f50b9638.mp4~~ Old demo. Replaced with:

https://user-images.githubusercontent.com/1430060/187306338-8a1ddc78-346d-4c60-aaea-c27fba97947b.mp4

### Notes

~~The performance, despite all the tweaks, is quite dismal.~~ Improved in [952496a](https://github.com/azavea/iow-boundary-tool/pull/50/commits/952496a62d1f03abc216aa83d1059cc38718c5cb) and [36d5585](https://github.com/azavea/iow-boundary-tool/pull/50/commits/36d558543b59d34838a95c8792f38c5295c348e5)

~~One avenue to investigate may be to fetch images from the [MapServer](https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/MapServer/1) rather than features from the [FeatureServer](https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/FeatureServer/1).~~ Implemented in [952496a](https://github.com/azavea/iow-boundary-tool/pull/50/commits/952496a62d1f03abc216aa83d1059cc38718c5cb).

~~Another improvement we can make is to show the Parcel Centroids, which are also available as a layer, at lower zoom levels. This will give users _something_ rather than nothing.~~ Implemented in [1c7c41c](https://github.com/azavea/iow-boundary-tool/pull/50/commits/1c7c41c69da518e7a7b77f534d0c69e70c25f005).

## Testing Instructions

- Check out this branch and `server`
- Go to http://localhost:4545/draw
  - [ ] Ensure you see a disabled Parcel data layer button in the sidebar
- Zoom in to the map
  - [ ] Ensure the button turns on once you are zoomed in enough
  - [ ] Ensure the layer appears, as styled in Figma, when you are zoomed in enough
  - [ ] Ensure you can toggle the layer on and off while zoomed in enough

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
