### PR TITLE
Set editing polygon border color by basemap type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorporated changes in app template [#31](https://github.com/azavea/iow-boundary-tool/pull/31)
 - Update styles for Polygon and Municipal Boundary layers [#48](https://github.com/azavea/iow-boundary-tool/pull/48)
 - Update tiles for all basemaps [#48](https://github.com/azavea/iow-boundary-tool/pull/48)
+- Update Edit Polygon border to be lighter on dark backgrounds [#58](https://github.com/azavea/iow-boundary-tool/pull/58)
 
 ### Fixed
 

--- a/src/app/src/components/DrawMap/useEditingPolygon.js
+++ b/src/app/src/components/DrawMap/useEditingPolygon.js
@@ -8,7 +8,6 @@ import { updatePolygon } from '../../store/mapSlice';
 import { customizePrototypeIcon } from '../../utils';
 
 const POLYGON_LAYER_OPTIONS = {
-    color: 'black',
     weight: 1,
     fillColor: 'black',
     fillOpacity: '.3',
@@ -39,7 +38,7 @@ function styleMidpointElement(element) {
 export default function useEditingPolygon() {
     const dispatch = useDispatch();
     const map = useMap();
-    const { polygon, editMode } = useSelector(state => state.map);
+    const { polygon, editMode, basemapType } = useSelector(state => state.map);
 
     const updatePolygonFromDrawEvent = useCallback(
         event => {
@@ -58,7 +57,10 @@ export default function useEditingPolygon() {
         if (polygon && polygon.visible) {
             const polygonLayer = new L.Polygon(
                 polygon.points.map(point => new L.latLng(point[0], point[1])),
-                POLYGON_LAYER_OPTIONS
+                {
+                    ...POLYGON_LAYER_OPTIONS,
+                    color: basemapType === 'satellite' ? 'white' : 'black',
+                }
             );
 
             if (editMode) {
@@ -78,5 +80,5 @@ export default function useEditingPolygon() {
                 }
             };
         }
-    }, [polygon, editMode, map, updatePolygonFromDrawEvent]);
+    }, [polygon, editMode, basemapType, map, updatePolygonFromDrawEvent]);
 }


### PR DESCRIPTION
## Overview

This PR adds code to update the editing polygon's border when the basemap is changed. If the basemap is Satellite, the border will be white, otherwise the border is black. 

Closes #56 

### Demo

<img width="477" alt="Screen Shot 2022-09-07 at 9 23 31 AM" src="https://user-images.githubusercontent.com/8356789/188902799-ceeb0f95-090f-4773-baa3-3a50cc871604.png">

### Notes

Information about the border type could be moved to the basemap components. Then when the basemap components are mounted, they can set the border type in state. The polygon would read this value from state and update accordingly. I didn't do this for this PR because the card asks for the simplest/easiest solution. 

## Testing Instructions

- Go to Draw Page
- Add a polygon
- Change the basemap
- Default and Land and Water basemaps should have the dark border, while satellite should have the light border.

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
