### PR TITLE
Save layer corners on layer remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix react-remove-scroll-bar warning [#29](https://github.com/azavea/iow-boundary-tool/pull/29)
+- Don't move reference image when panning map [#59](https://github.com/azavea/iow-boundary-tool/pull/59)
 
 ### Deprecated
 

--- a/src/app/src/components/Layers/ReferenceImageLayer.js
+++ b/src/app/src/components/Layers/ReferenceImageLayer.js
@@ -66,6 +66,27 @@ function ReferenceImageLayer() {
             layer.on('dragend', updateImageHandler);
             layer.on('refresh', updateImageHandler);
 
+            /**
+             * This is handler is added to save the default position of the
+             * reference image. It uses the remove event because the corners
+             * don't always exist on the add event. Also, corners might not
+             * be set for some remove events, so their their existence is
+             * verified before dispatching an update,
+             */
+            if (!corners) {
+                layer.on('remove', ({ target: layer }) => {
+                    if (layer._corners) {
+                        dispatch(
+                            updateReferenceImage({
+                                corners: layer._corners.map(
+                                    convertCornerToStateFormat
+                                ),
+                            })
+                        );
+                    }
+                });
+            }
+
             return layer;
         },
         // TODO: Figure out how to prevent deselect on re-render


### PR DESCRIPTION
## Overview

This PR adds an event handler to the reference image layer `remove` event to save the layer's corners if they aren't already saved. This allows the position of the layer to be saved, even if it has not been edited. 

Closes #55 

### Demo

https://user-images.githubusercontent.com/8356789/188916595-e9906146-c8e5-4f07-9a0e-2a2750139dca.mov

### Notes

While the add event might make more sense, the corners are not loaded at that time. The reason for the conditional layer._corners check is that corners are not always loaded when the layer remove event is fired. For example, the remove event is fired twice while adding the reference image.

## Testing Instructions

- Go to draw page
- Make note of reference image location, but don't edit it
- Turn off reference image
- Move map
- Turn on reference image
- The reference image should be in the original location (on earth, not the screen)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
