### PR TITLE
Allow user to upload reference images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Parcel Layer [#50](https://github.com/azavea/iow-boundary-tool/pull/50)
 - Add distorable reference image layer [#46](https://github.com/azavea/iow-boundary-tool/pull/46)
 - Add Land & water basemap [#48](https://github.com/azavea/iow-boundary-tool/pull/48)
+- Add user reference image upload [#60](https://github.com/azavea/iow-boundary-tool/pull/60)
 
 ### Changed
 

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -25,3 +25,5 @@ export const NC_SOUTH = 33.851169;
 
 export const PARCELS_LAYER_URL =
     'https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/MapServer';
+
+export const SIDEBAR_TEXT_TOOLTIP_THRESHOLD = 30;

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMap } from 'react-leaflet';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { convertIndexedObjectToArray } from './utils';
+import {
+    createDefaultReferenceImage,
+    updateReferenceImage,
+} from './store/mapSlice';
 
 export function useDialogController() {
     const [isOpen, setIsOpen] = useState(false);
@@ -70,4 +76,37 @@ export function useMapLayer(layer) {
 
 export function useLayerVisibility(layer) {
     return useSelector(state => state.map.layers).includes(layer);
+}
+
+export function useAddReferenceImage() {
+    const dispatch = useDispatch();
+
+    return file => {
+        const url = URL.createObjectURL(file);
+        dispatch(
+            updateReferenceImage({
+                url,
+                update: createDefaultReferenceImage(file.name),
+            })
+        );
+    };
+}
+
+export function useFilePicker(onChange) {
+    const openFileDialog = () => {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.multiple = true;
+        input.onchange = handlePickFiles;
+        input.accept = 'image/png, image/jpeg, .png, .jpg, .jpeg';
+
+        input.click();
+    };
+
+    const handlePickFiles = event => {
+        onChange(convertIndexedObjectToArray(event.target.files));
+        event.target.remove();
+    };
+
+    return openFileDialog;
 }

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -9,14 +9,17 @@ const initialState = {
     basemapType: 'default',
     geocodeResult: null,
     mapZoom: MAP_INITIAL_ZOOM,
-    referenceImage: {
-        visible: true,
-        corners: null,
-        mode: 'distort',
-        transparent: false,
-        outlined: false,
-    },
+    referenceImages: {},
 };
+
+export const createDefaultReferenceImage = name => ({
+    name,
+    visible: true,
+    corners: null,
+    mode: 'distort',
+    transparent: false,
+    outlined: false,
+});
 
 const DEFAULT_POLYGON = {
     points: [],
@@ -93,11 +96,15 @@ export const mapSlice = createSlice({
         setMapZoom: (state, { payload: mapZoom }) => {
             state.mapZoom = mapZoom;
         },
-        toggleReferenceImageVisibility: state => {
-            state.referenceImage.visible = !state.referenceImage.visible;
+        toggleReferenceImageVisibility: (state, { payload: url }) => {
+            state.referenceImages[url].visible =
+                !state.referenceImages[url].visible;
         },
-        updateReferenceImage: (state, { payload: update }) => {
-            state.referenceImage = { ...state.referenceImage, ...update };
+        updateReferenceImage: (state, { payload: { url, update } }) => {
+            state.referenceImages[url] = {
+                ...(state.referenceImages?.[url] ?? {}),
+                ...update,
+            };
         },
     },
 });


### PR DESCRIPTION

## Overview

This PR adds the ability for the user to upload their own images. These images will appear as toggleable reference layers in the sidebar. 

Closes #54 

### Demo

https://user-images.githubusercontent.com/8356789/188991408-7542d4a7-3e75-4faf-8515-a58ce849e1b1.mov

### Notes

This PR updates the ReferenceLayer component to store the individual reference image layers in a mutable react ref. This cuts down on the number of times these layers are re-created; a high number of re-creations has caused unpredictable behavior. 

I first tried using L.DistortableImage's distortableCollection to store multiple distortable layers, but this would make the reference images uneditable.

As is evident in the demo video above, if the file names are long, they are cutoff by the end of the sidebar. This should be addressed especially as reference images may come in sets with files that begin with the same prefix (e.g. see demo).

## Testing Instructions

- Go to Welcome page
- Navigate to last section, File Upload
- Upload some image files
- Click Continue
- The images should show up as reference layers on the map
- Click the "Upload File" button to add more reference layers
- See that they show up on the map as well
- Ensure all layers are toggleable and editable and that they are saving correctly when toggled

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
