### PR TITLE
Add labels to municipal boundaries layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add distorable reference image layer [#46](https://github.com/azavea/iow-boundary-tool/pull/46)
 - Add Land & water basemap [#48](https://github.com/azavea/iow-boundary-tool/pull/48)
 - Add user reference image upload [#60](https://github.com/azavea/iow-boundary-tool/pull/60)
+- Add labels to municipal boundary layer [#61](https://github.com/azavea/iow-boundary-tool/pull/61)
 
 ### Changed
 

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -59,3 +59,21 @@
     border-radius: 50%;
     background-color: var(--chakra-colors-black);
 }
+
+/* end Leaflet.DistortableImage overrides */
+
+.muni-label {
+    background: rgba(255, 255, 255, 0);
+    border: 0;
+    border-radius: 0px;
+    box-shadow: 0 0px 0px;
+    font-weight: bold;
+    font-size: var(--chakra-fontSizes-sm);
+    color: var(--chakra-colors-purple-900);
+    text-shadow: 0 0 0.2em var(--chakra-colors-purple-50), 0 0 0.2em var(--chakra-colors-purple-50);
+}
+
+.muni-label-light {
+    color: var(--chakra-colors-purple-50);
+    text-shadow: 0 0 0.2em var(--chakra-colors-purple-900), 0 0 0.2em var(--chakra-colors-purple-900);
+}

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -27,3 +27,5 @@ export const PARCELS_LAYER_URL =
     'https://services.nconemap.gov/secure/rest/services/NC1Map_Parcels/MapServer';
 
 export const SIDEBAR_TEXT_TOOLTIP_THRESHOLD = 30;
+
+export const MUNICIPAL_BOUNDARY_LABELS_MIN_ZOOM_LEVEL = 9;


### PR DESCRIPTION
## Overview

This PR adds labels to the municipal boundaries layer.

If the zoom level is less than 9, the labels are not shown as this gets too busy.
On the satellite basemap, the labels are white text instead of the default black.

Closes #49 

### Demo

<img width="585" alt="Screen Shot 2022-09-08 at 9 49 59 AM" src="https://user-images.githubusercontent.com/8356789/189153965-920d2792-7d38-4d27-ae16-4bc9c265dddf.png">

<img width="483" alt="Screen Shot 2022-09-08 at 9 50 06 AM" src="https://user-images.githubusercontent.com/8356789/189154003-22bfa092-c687-4689-a621-cfa9ba6e9c04.png">

## Testing Instructions

- Go to draw map page
- Enable municipal boundaries layer
- Zoom in past zoom level 9
- Labels should be present
- Switch to satellite basemap
- The labels should now be white text

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
