### PR TITLE
Update task to use var defined in group_vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix react-remove-scroll-bar warning [#29](https://github.com/azavea/iow-boundary-tool/pull/29)
 - Don't move reference image when panning map [#59](https://github.com/azavea/iow-boundary-tool/pull/59)
+- Fix ansible task to use var defined in group_vars [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
 
 ### Deprecated
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
   # config.vm.network :forwarded_port, guest: 5432, host: 5432
 
   # Gunicorn (Django)
-  # config.vm.network :forwarded_port, guest: 8080, host: 8080
+  config.vm.network :forwarded_port, guest: 8181, host: 8181
 
   # Debug server (Python)
   # config.vm.network :forwarded_port, guest: 8081, host: 8081

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -4,7 +4,7 @@ pip_version: "20.3.*"
 aws_cli_version: "1.18.*"
 aws_profile: "iow-boundary-tool"
 
-project_name_settings_bucket: "iow-boundary-tool-development-config-us-east-1"
+iow_boundary_tool_settings_bucket: "iow-boundary-tool-development-config-us-east-1"
 
 docker_version: "5:19.*"
 docker_compose_version: "1.27.4"

--- a/deployment/ansible/roles/iow-boundary-tool.environment/tasks/main.yml
+++ b/deployment/ansible/roles/iow-boundary-tool.environment/tasks/main.yml
@@ -9,4 +9,4 @@
   lineinfile:
     path: "/etc/environment"
     regexp: "^IOW_BOUNDARY_TOOL_SETTINGS_BUCKET="
-    line: "IOW_BOUNDARY_TOOL_SETTINGS_BUCKET={{ iow-boundary-tool-development-config-us-east-1 }}"
+    line: "IOW_BOUNDARY_TOOL_SETTINGS_BUCKET={{ iow_boundary_tool_settings_bucket }}"


### PR DESCRIPTION
## Overview

When running `scripts/setup -–vagrant`, provisioning would eventually fail at the Ansible task `Set IOW_BOUNDARY_TOOL_SETTINGS_BUCKET` with the below error output:
```
TASK [iow-boundary-tool.environment : Set IOW_BOUNDARY_TOOL_SETTINGS_BUCKET] ***
fatal: [default]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'iow' is undefined\n\nThe error appears to be in '/vagrant/deployment/ansible/roles/iow-boundary-tool.environment/tasks/main.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set IOW_BOUNDARY_TOOL_SETTINGS_BUCKET\n  ^ here\n"}

RUNNING HANDLER [azavea.docker : Restart Docker] *******************************

PLAY RECAP *********************************************************************
default                    : ok=14   changed=11   unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

The ansible task was unable to find the right variable within the play because we were trying to evaluate an environment variable that wasn't set in `group_vars`. This renames the variable defined in the `group_vars` file to the appropriate project name and adjusts the task to use the renamed variable to set `IOW_BOUNDARY_TOOL_SETTINGS_BUCKET` instead.

### Demo
```
TASK [iow-boundary-tool.environment : Set AWS_PROFILE] *************************
ok: [default]

TASK [iow-boundary-tool.environment : Set IOW_BOUNDARY_TOOL_SETTINGS_BUCKET] ***
ok: [default]
```
## Testing Instructions

- `scripts/setup –-vagrant`
-  Confirm `IOW_BOUNDARY_TOOL_SETTINGS_BUCKET` set to the correct value in the Ansible task logs
-  Confirm vagrant vm provisions successfully


## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
