### PR TITLE
Make `Roles` enum an `IntEnum` subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update tiles for all basemaps [#48](https://github.com/azavea/iow-boundary-tool/pull/48)
 - Update Edit Polygon border to be lighter on dark backgrounds [#58](https://github.com/azavea/iow-boundary-tool/pull/58)
 - Split DrawMap commponents into Layers and DrawTools [#57](https://github.com/azavea/iow-boundary-tool/pull/57)
+- Make `Roles` enum an `IntEnum` subclass [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
 
 ### Fixed
 

--- a/src/django/api/management/commands/resetdb.py
+++ b/src/django/api/management/commands/resetdb.py
@@ -2,6 +2,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
 from api.models import Role, Utility, User
+from api.models.role import Roles
 
 
 class Command(BaseCommand):
@@ -23,11 +24,11 @@ class Command(BaseCommand):
         User.objects.create_user(
             email="v1@azavea.com",
             password="password",
-            role=Role.objects.get(description="VALIDATOR"),
+            role=Role.objects.get(pk=Roles.VALIDATOR),
         )
         contributor = User.objects.create_user(
             email="c1@azavea.com",
             password="password",
-            role=Role.objects.get(description="CONTRIBUTOR"),
+            role=Role.objects.get(pk=Roles.CONTRIBUTOR),
         )
         contributor.utilities.add(test_utility)

--- a/src/django/api/models/role.py
+++ b/src/django/api/models/role.py
@@ -1,11 +1,11 @@
-from enum import Enum, unique
+from enum import IntEnum, unique
 from django.db import models
 
 __all__ = ["Role"]
 
 
 @unique
-class Roles(Enum):
+class Roles(IntEnum):
     """Corresponds to the order of pks in initial migration
     0002_create_initial_roles."""
 

--- a/src/django/api/models/user.py
+++ b/src/django/api/models/user.py
@@ -44,7 +44,7 @@ class EmailAsUsernameUserManager(BaseUserManager):
         if extra_fields.get("is_superuser") is not True:
             raise ValueError("Superuser must have is_superuser=True.")
 
-        admin_role = Role.objects.get(pk=Roles.ADMINISTRATOR.value)
+        admin_role = Role.objects.get(pk=Roles.ADMINISTRATOR)
         return self._create_user(email, admin_role, password, **extra_fields)
 
 
@@ -63,7 +63,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         Role,
         related_name="actors",
         on_delete=models.PROTECT,
-        default=Roles.CONTRIBUTOR.value,
+        default=Roles.CONTRIBUTOR,
     )
 
     utilities = models.ManyToManyField(
@@ -75,7 +75,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     def clean(self):
         if (
             self.id
-            and self.role.description == "CONTRIBUTOR"
+            and self.role.pk == Roles.CONTRIBUTOR
             and not self.utilities.exists()
         ):
             raise ValidationError("Contributors must be assigned a utility.")


### PR DESCRIPTION
## Overview

While #73 was in review, #72 introduced a `Roles` enum. It wasn't particularly attractive to work with because it didn't subclass `IntEnum`. Now, it's an `IntEnum`, and it's used where possible.

Follow-up to https://github.com/azavea/iow-boundary-tool/pull/73#discussion_r975662996.

## Testing Instructions

- [x] `scripts/resetdb` should succeed
- [ ] `scripts/manage createsuperuser` should succeed

- `scripts/manage shell`
- Run these commands and verify `full_clean()` still emits a `ValidationError` as show:
```
from api.models import User
c1 = User.objects.get(email='c1@azavea.com')
c1.utilities.set([])
c1.full_clean()
```
```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.8/site-packages/django/db/models/base.py", line 1251, in full_clean
    raise ValidationError(errors)
django.core.exceptions.ValidationError: {'__all__': ['Contributors must be assigned a utility.']}
```

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
