### PR TITLE
Implement reset password functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom user model and define roles [#72](https://github.com/azavea/iow-boundary-tool/pull/72)
 - Add utility model and test development users [#73](https://github.com/azavea/iow-boundary-tool/pull/73)
 - Add login interface [#77](https://github.com/azavea/iow-boundary-tool/pull/77)
+- Add reset password functionality [#79](https://github.com/azavea/iow-boundary-tool/pull/79)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -3,6 +3,8 @@ import { BrowserRouter, Navigate, Routes, Route } from 'react-router-dom';
 
 import './App.css';
 import Login from './pages/Login';
+import ForgotPassword from './pages/ForgotPassword';
+import ResetPassword from './pages/ResetPassword';
 import Welcome from './pages/Welcome';
 import Draw from './pages/Draw';
 import Map from './components/Map';
@@ -10,31 +12,41 @@ import Sidebar from './components/Sidebar';
 
 import PrivateRoute from './components/PrivateRoute';
 
+const privateRoutes = (
+    <PrivateRoute>
+        <Flex>
+            <Routes>
+                <Route path='/draw' element={<Sidebar />} />
+            </Routes>
+            <Box flex={1} position='relative'>
+                <Map>
+                    <Routes>
+                        <Route path='/welcome' element={<Welcome />} />
+                        <Route path='/draw' element={<Draw />} />
+                        <Route
+                            path='/'
+                            element={<Navigate to='/welcome' replace />}
+                        />
+                    </Routes>
+                </Map>
+            </Box>
+        </Flex>
+    </PrivateRoute>
+);
+
 function App() {
     return (
         <BrowserRouter>
             <Routes>
                 <Route path='/login' element={<Login />} />
+                <Route path='/forgot' element={<ForgotPassword />} />
+                <Route path='/reset' element={<ResetPassword />} />
+                <Route
+                    path='/confirm_password_reset/reset/*'
+                    element={<ResetPassword />}
+                />
+                <Route path='*' element={privateRoutes} />
             </Routes>
-            <PrivateRoute>
-                <Flex>
-                    <Routes>
-                        <Route path='/draw' element={<Sidebar />} />
-                    </Routes>
-                    <Box flex={1} position='relative'>
-                        <Map>
-                            <Routes>
-                                <Route path='/welcome' element={<Welcome />} />
-                                <Route path='/draw' element={<Draw />} />
-                                <Route
-                                    path='/'
-                                    element={<Navigate to='/welcome' replace />}
-                                />
-                            </Routes>
-                        </Map>
-                    </Box>
-                </Flex>
-            </PrivateRoute>
         </BrowserRouter>
     );
 }

--- a/src/app/src/components/LoginForm.js
+++ b/src/app/src/components/LoginForm.js
@@ -1,0 +1,10 @@
+import { Box, VStack } from '@chakra-ui/react';
+
+export default function LoginForm({ children }) {
+    return (
+        <VStack bg='gray.50' h='100vh' spacing={5}>
+            <Box h='20%'></Box>
+            {children}
+        </VStack>
+    );
+}

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -42,4 +42,6 @@ export const PANES = {
 export const API_URLS = {
     LOGIN: 'api/auth/login/',
     LOGOUT: 'api/auth/logout/',
+    FORGOT: 'api/auth/password/reset/',
+    RESET: 'api/auth/password/reset/confirm/',
 };

--- a/src/app/src/pages/ForgotPassword.js
+++ b/src/app/src/pages/ForgotPassword.js
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Box, Button, Input, Text } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+
+import { API } from '../api';
+import { API_URLS } from '../constants';
+import LoginForm from '../components/LoginForm';
+import { formatApiError } from '../utils';
+
+export default function ForgotPassword() {
+    const [email, setEmail] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [errorDetail, setErrorDetail] = useState('');
+    const navigate = useNavigate();
+
+    const forgotPasswordRequest = () => {
+        API.post(API_URLS.FORGOT, { email })
+            .then(() => {
+                setSuccess(true);
+                setErrorDetail('');
+            })
+            .catch(apiError => {
+                setSuccess(false);
+                setErrorDetail(formatApiError(apiError.response?.data));
+            });
+    };
+
+    return (
+        <LoginForm>
+            {success ? (
+                <>
+                    <Text textStyle='forgotPasswordHeader'>
+                        If an account exists for {email}, instructions for
+                        resetting your password have been sent.
+                    </Text>
+                    <Button variant='cta' onClick={() => navigate('/login')}>
+                        Login
+                    </Button>
+                </>
+            ) : (
+                <>
+                    <Text fontFamily='heading' fontSize='lg'>
+                        Forgot password?
+                    </Text>
+                    {errorDetail && (
+                        <Text textStyle='apiError' align='center'>
+                            {errorDetail}
+                        </Text>
+                    )}
+                    <Box>
+                        <Text fontFamily='body' fontSize='sm' align='center'>
+                            You will receive password reset instructions by
+                            email.
+                        </Text>
+                    </Box>
+                    <Input
+                        htmlSize={32}
+                        width='auto'
+                        bg='white'
+                        aria-label='email'
+                        placeholder='email'
+                        type='email'
+                        isInvalid={!!errorDetail}
+                        onChange={({ target: { value } }) => setEmail(value)}
+                        onKeyPress={e => {
+                            if (e.key === 'Enter') {
+                                forgotPasswordRequest(email);
+                            }
+                        }}
+                    />
+                    <Button
+                        w='320px'
+                        variant='cta'
+                        onClick={() => forgotPasswordRequest(email)}
+                    >
+                        Continue
+                    </Button>
+                </>
+            )}
+        </LoginForm>
+    );
+}

--- a/src/app/src/pages/Login.js
+++ b/src/app/src/pages/Login.js
@@ -6,11 +6,13 @@ import { Box, Button, Input, Text, VStack } from '@chakra-ui/react';
 import { API } from '../api';
 import { API_URLS } from '../constants';
 import { login } from '../store/authSlice';
+import LoginForm from '../components/LoginForm';
 
 export default function Login() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [errorDetail, setErrorDetail] = useState('');
+    const [forgotPassword, setForgotPassword] = useState(false);
     const dispatch = useDispatch();
     const navigate = useNavigate();
 
@@ -37,14 +39,16 @@ export default function Login() {
         if (signedIn) {
             navigate(locationBeforeAuth, { replace: true });
         }
-    }, [navigate, signedIn, locationBeforeAuth]);
+        if (forgotPassword) {
+            navigate('/forgot');
+        }
+    }, [navigate, signedIn, forgotPassword, locationBeforeAuth]);
 
     return (
-        <VStack bg='gray.50' h='100vh' spacing={5}>
-            <Box h='20%'></Box>
+        <LoginForm>
             <Text textStyle='loginHeader'>Boundary Sync</Text>
             <Box>
-                <Text textStyle='loginError'>{errorDetail}</Text>
+                <Text textStyle='apiError'>{errorDetail}</Text>
             </Box>
             <Input
                 htmlSize={32}
@@ -81,8 +85,13 @@ export default function Login() {
                 >
                     Login
                 </Button>
-                <Button variant='minimal'>Forgot password?</Button>
+                <Button
+                    variant='minimal'
+                    onClick={() => setForgotPassword(true)}
+                >
+                    Forgot password?
+                </Button>
             </VStack>
-        </VStack>
+        </LoginForm>
     );
 }

--- a/src/app/src/pages/ResetPassword.js
+++ b/src/app/src/pages/ResetPassword.js
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Box, Button, Input, Text } from '@chakra-ui/react';
+
+import { API } from '../api';
+import { API_URLS } from '../constants';
+import LoginForm from '../components/LoginForm';
+
+export default function ResetPassword() {
+    const [newPassword1, setNewPassword1] = useState('');
+    const [newPassword2, setNewPassword2] = useState('');
+    const [success, setSuccess] = useState(false);
+    const [errorDetail, setErrorDetail] = useState('');
+    const [disableSubmit, setDisableSubmit] = useState(false);
+
+    const location = useLocation();
+    const navigate = useNavigate();
+    const uid = location.pathname.split('/')[3];
+    const token = location.pathname.split('/')[4];
+
+    if ((!uid || !token) && !errorDetail) {
+        setErrorDetail('The link you followed is no longer valid.');
+        setDisableSubmit(true);
+    }
+
+    const formatApiError = apiErrorData => {
+        var errorDetail = 'An unknown error occurred.';
+        var passwordErrorSeen = false;
+
+        for (const [field, errorArray] of Object.entries(apiErrorData)) {
+            if (['uid', 'token'].includes(field)) {
+                errorDetail = 'The link you followed is no longer valid.';
+            } else if (!passwordErrorSeen) {
+                // Avoid duplicating password error messages
+                var formattedField;
+                if (field.includes('password')) {
+                    // new_password_1 -> Password
+                    formattedField = 'Password';
+                    passwordErrorSeen = true;
+                } else {
+                    formattedField = `${field[0].toUpperCase()}${field.slice(
+                        1
+                    )}`;
+                }
+                errorDetail = `${formattedField}: ${errorArray.join(' ')}`;
+            }
+        }
+        return errorDetail;
+    };
+
+    const forgotPasswordRequest = () => {
+        API.post(API_URLS.RESET, {
+            uid,
+            token,
+            new_password1: newPassword1,
+            new_password2: newPassword2,
+        })
+            .then(() => {
+                setSuccess(true);
+                setErrorDetail('');
+            })
+            .catch(apiError => {
+                setSuccess(false);
+                setErrorDetail(formatApiError(apiError.response?.data));
+            });
+    };
+
+    function makePasswordInput(setter, placeholder) {
+        return (
+            <Input
+                htmlSize={32}
+                width='auto'
+                bg='white'
+                aria-label={placeholder}
+                placeholder={placeholder}
+                type='password'
+                isInvalid={!!errorDetail && !disableSubmit}
+                disabled={disableSubmit}
+                onChange={({ target: { value } }) => setter(value)}
+                onKeyPress={e => {
+                    if (e.key === 'Enter') {
+                        forgotPasswordRequest(
+                            uid,
+                            token,
+                            newPassword1,
+                            newPassword2
+                        );
+                    }
+                }}
+            />
+        );
+    }
+
+    let resultOrInstruction;
+    if (success) {
+        resultOrInstruction = 'Your password has been reset';
+    } else {
+        if (disableSubmit) {
+            resultOrInstruction = '';
+        } else {
+            resultOrInstruction = 'Choose a new password (8+ characters)';
+        }
+    }
+
+    return (
+        <LoginForm>
+            <Text fontFamily='heading' fontSize='lg'>
+                Reset Password
+            </Text>
+            <Box>
+                {errorDetail && (
+                    <Text textStyle='apiError' align='center'>
+                        {errorDetail}
+                    </Text>
+                )}
+                <Text fontFamily='body' fontSize='md' align='center'>
+                    {resultOrInstruction}
+                </Text>
+            </Box>
+            {success ? (
+                <Button variant='cta' onClick={() => navigate('/login')}>
+                    Login
+                </Button>
+            ) : (
+                <>
+                    {makePasswordInput(setNewPassword1, 'new password')}
+                    {makePasswordInput(setNewPassword2, 'new password (again)')}
+                    <Button
+                        w='320px'
+                        variant='cta'
+                        disabled={disableSubmit}
+                        onClick={() =>
+                            forgotPasswordRequest(
+                                uid,
+                                token,
+                                newPassword1,
+                                newPassword2
+                            )
+                        }
+                    >
+                        Continue
+                    </Button>
+                </>
+            )}
+        </LoginForm>
+    );
+}

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -129,7 +129,7 @@ const theme = extendTheme({
             alignItems: 'center',
             bg: 'gray.50',
         },
-        loginError: {
+        apiError: {
             fontSize: 'md',
             alignItems: 'center',
             color: 'red.600',

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -64,3 +64,12 @@ export function customizePrototypeIcon(prototype, className) {
     prototype.options.icon = new L.DivIcon({ className });
     prototype.options.touchIcon = prototype.options.icon;
 }
+
+export function formatApiError(apiErrorData) {
+    var errorDetail = '';
+    for (const [field, errorArray] of Object.entries(apiErrorData)) {
+        const formattedField = `${field[0].toUpperCase()}${field.slice(1)}`;
+        errorDetail += `${formattedField}: ${errorArray.join(' ')}`;
+    }
+    return errorDetail || 'An unknown error occurred.';
+}

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -263,3 +263,12 @@ ECSMANAGE_ENVIRONMENTS = {
         'AWS_REGION': 'us-east-1',
     }
 }
+
+# Email
+
+if ENVIRONMENT == 'Development':
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    DEFAULT_FROM_EMAIL = 'noreply@iow.test'
+else:
+    EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
+    DEFAULT_FROM_EMAIL = os.getenv('IOW_DEFAULT_FROM_EMAIL')

--- a/src/django/iow/urls.py
+++ b/src/django/iow/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
     path('health-check/', include('watchman.urls')),
+    path('confirm_password_reset/', include('django.contrib.auth.urls')),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Overview
Implement a token-based reset password flow.

Closes #68 

### Demo
<img width="400" alt="Screen Shot 2022-09-27 at 2 35 27 PM" src="https://user-images.githubusercontent.com/38668450/192608492-2b1397fb-0a13-4541-9911-d0f18357d56c.png">

### Notes
Django's [default expiration interval](https://docs.djangoproject.com/en/3.2/ref/settings/#password-reset-timeout) for password reset tokens is 3 days, as they explain that the attack vector is unlikely. I think 3 days is good, as it allows a typical weekend to elapse.

## Testing Instructions

- `./scripts/server`
- While logged out, visit localhost:4545/ and click Forgot password?
- Enter no email, verify feedback well styled
- Enter a test user's email
- Follow the link from the email printed to the server logs
- Complete the form with poor information (blank, password mismatch, only numeric), verify feedback well styled
- Complete the form with correct information
- Follow the link to login and attempt login with those new creds, verify success
- Attempt to repeat; verify that the link is no longer valid (and feedback well styled)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
