### PR TITLE
Fix slow performance of Django server in Docker 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ vagrant ssh
 ./scripts/server
 ```
 
+After running `setup` (or `resetdb`), three test users are created:
+
+| User                 | Password          | Role          |
+| ---------------------|-------------------|---------------|
+| a1@azavea.com        | password          | administrator |
+| v1@azavea.com        | password          | validator     |
+| c1@azavea.com        | password          | contributor   |
+
 ### Ports
 
 | Service            | Port                            |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
     working_dir: /usr/local/src
     command:
       - "-b :8181"
+      - "--workers=2"
       - "--reload"
       - "--timeout=90"
       - "--access-logfile=-"

--- a/src/django/Dockerfile
+++ b/src/django/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT ["/usr/local/bin/gunicorn"]
 
 COPY . /usr/local/src
 
-CMD ["-b :8080", \
+CMD ["-b :8181", \
 "--workers=2", \
 "--timeout=60", \
 "--access-logfile=-", \


### PR DESCRIPTION
## Overview
1. Similar to 598a0b3ddc5c49a9aea9001ddf7293bbe926d31e, update a port number to agree with the README (see Line 54 of the README).
2. More substantively, increase the number of `gunicorn` workers to 2, so that requests don't block each other and cause worker timeouts.

## Testing instructions
- `scripts/update --docker`
- `scripts/server`
- Visit the Django admin at localhost:8181/admin (in Chrome, since the error was not reproducible for me in Safari), and visit multiple pages: ensure app does not lock up.

## Notes
See similar approach here:
https://github.com/azavea/iow-boundary-tool/blob/2b3f90bbacd1377ee2734b6da557c51cb8e50a6a/src/django/Dockerfile#L28