### PR TITLE
Style submissions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add reset password functionality [#79](https://github.com/azavea/iow-boundary-tool/pull/79)
 - Create Remaining Initial Django Models [#82](https://github.com/azavea/iow-boundary-tool/pull/82)
 - Force users to reset password on first login [#83](https://github.com/azavea/iow-boundary-tool/pull/83)
+- Style submissions list [#99](https://github.com/azavea/iow-boundary-tool/pull/99)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,5 +1,11 @@
 import { Box, Flex } from '@chakra-ui/react';
-import { BrowserRouter, Navigate, Routes, Route } from 'react-router-dom';
+import {
+    BrowserRouter,
+    Outlet,
+    Navigate,
+    Routes,
+    Route,
+} from 'react-router-dom';
 
 import './App.css';
 import Login from './pages/Login';
@@ -8,6 +14,7 @@ import ResetPassword from './pages/ResetPassword';
 import Welcome from './pages/Welcome';
 import Draw from './pages/Draw';
 import Map from './components/Map';
+import Submissions from './pages/Submissions';
 import Sidebar from './components/Sidebar';
 
 import PrivateRoute from './components/PrivateRoute';
@@ -19,16 +26,24 @@ const privateRoutes = (
                 <Route path='/draw' element={<Sidebar />} />
             </Routes>
             <Box flex={1} position='relative'>
+                {/* Map routes */}
                 <Map>
                     <Routes>
                         <Route path='/welcome' element={<Welcome />} />
                         <Route path='/draw' element={<Draw />} />
-                        <Route
-                            path='/'
-                            element={<Navigate to='/welcome' replace />}
-                        />
                     </Routes>
                 </Map>
+                {/* Non-map routes */}
+                <Routes>
+                    <Route path='/submissions' element={<Submissions />} />
+                    {/* Avoid redirecting map routes */}
+                    <Route path='/welcome' element={<Outlet />} />
+                    <Route path='/draw' element={<Outlet />} />
+                    <Route
+                        path='*'
+                        element={<Navigate to='/welcome' replace />}
+                    />
+                </Routes>
             </Box>
         </Flex>
     </PrivateRoute>

--- a/src/app/src/components/SubmissionBadges.js
+++ b/src/app/src/components/SubmissionBadges.js
@@ -1,0 +1,17 @@
+import { Badge } from '@chakra-ui/react';
+
+export function SubmittedBadge() {
+    return (
+        <Badge bg='#38B2AC' variant='solid' colorScheme='green'>
+            SUBMITTED
+        </Badge>
+    );
+}
+
+export function DraftBadge() {
+    return (
+        <Badge variant='solid' colorScheme='yellow'>
+            DRAFT
+        </Badge>
+    );
+}

--- a/src/app/src/components/SubmissionsList.js
+++ b/src/app/src/components/SubmissionsList.js
@@ -1,0 +1,1 @@
+export default function SubmissionsList() {}

--- a/src/app/src/components/SubmissionsList.js
+++ b/src/app/src/components/SubmissionsList.js
@@ -1,1 +1,97 @@
-export default function SubmissionsList() {}
+import {
+    HStack,
+    Box,
+    Heading,
+    Icon,
+    Tabs,
+    TabList,
+    TabPanels,
+    Tab,
+    TabPanel,
+    Table,
+    Thead,
+    Tbody,
+    Tr,
+    Th,
+    Td,
+    TableContainer,
+    Text,
+} from '@chakra-ui/react';
+import {
+    ClockIcon,
+    FlagIcon,
+    LocationMarkerIcon,
+} from '@heroicons/react/solid';
+import { heroToChakraIcon } from '../utils';
+import { SubmittedBadge } from './SubmissionBadges';
+
+const tableHeaders = (
+    <Thead>
+        <Tr>
+            <Th>
+                <HStack>
+                    <Icon as={heroToChakraIcon(LocationMarkerIcon)} />
+                    <Text textStyle='tableHeading'>Location / PWSID</Text>
+                </HStack>
+            </Th>
+            <Th>
+                <HStack>
+                    <Icon as={heroToChakraIcon(ClockIcon)} />
+                    <Text textStyle='tableHeading'>Last modified</Text>
+                </HStack>
+            </Th>
+            <Th>
+                <HStack>
+                    <Icon as={heroToChakraIcon(FlagIcon)} />
+                    <Text textStyle='tableHeading'>Status</Text>
+                </HStack>
+            </Th>
+        </Tr>
+    </Thead>
+);
+
+export default function SubmissionsList() {
+    const getSubmissions = ({ active = true }) => {
+        return (
+            <TableContainer borderRadius='2px'>
+                <Table variant='submissions'>
+                    {tableHeaders}
+                    <Tbody>
+                        <Tr>
+                            <Td>
+                                <Text textStyle='utilityEntry'>Raleigh</Text>
+                                <Text textStyle='utilityId'>0111010</Text>
+                            </Td>
+                            <Td>
+                                <Text textStyle='timestamp'>
+                                    July 7, 2022 3:32 pm
+                                </Text>
+                            </Td>
+                            <Td>
+                                <SubmittedBadge />
+                            </Td>
+                        </Tr>
+                    </Tbody>
+                </Table>
+            </TableContainer>
+        );
+    };
+
+    return (
+        <Box paddingLeft={8} paddingRight={8} mt={6}>
+            <Heading size='lg'>Submissions</Heading>
+            <Tabs mt={3} isLazy>
+                <TabList borderBottom='0' mb={6}>
+                    <Tab>Active</Tab>
+                    <Tab>Archived</Tab>
+                </TabList>
+
+                <TabPanels>
+                    <TabPanel>{getSubmissions({})}</TabPanel>
+                    {/* archived tab is lazily fetched */}
+                    <TabPanel>{getSubmissions({ active: false })}</TabPanel>
+                </TabPanels>
+            </Tabs>
+        </Box>
+    );
+}

--- a/src/app/src/components/SubmissionsList.js
+++ b/src/app/src/components/SubmissionsList.js
@@ -1,8 +1,11 @@
 import {
     HStack,
     Box,
+    Button,
+    Flex,
     Heading,
     Icon,
+    Spacer,
     Tabs,
     TabList,
     TabPanels,
@@ -22,6 +25,7 @@ import {
     FlagIcon,
     LocationMarkerIcon,
 } from '@heroicons/react/solid';
+import { useNavigate } from 'react-router-dom';
 import { heroToChakraIcon } from '../utils';
 import { SubmittedBadge } from './SubmissionBadges';
 
@@ -77,9 +81,17 @@ export default function SubmissionsList() {
         );
     };
 
+    const navigate = useNavigate();
+
     return (
         <Box paddingLeft={8} paddingRight={8} mt={6}>
-            <Heading size='lg'>Submissions</Heading>
+            <Flex>
+                <Heading size='lg'>Submissions</Heading>
+                <Spacer />
+                <Button mr={4} onClick={() => navigate('/draw')}>
+                    Add map
+                </Button>
+            </Flex>
             <Tabs mt={3} isLazy>
                 <TabList borderBottom='0' mb={6}>
                     <Tab>Active</Tab>

--- a/src/app/src/pages/Submissions.js
+++ b/src/app/src/pages/Submissions.js
@@ -1,0 +1,5 @@
+import SubmissionsList from '../components/SubmissionsList';
+
+export default function Submissions() {
+    return <SubmissionsList />;
+}

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -105,6 +105,24 @@ const Tooltip = {
     },
 };
 
+const Table = {
+    variants: {
+        submissions: {
+            table: {
+                borderColor: 'gray.200',
+                borderWidth: '1px',
+            },
+            th: {
+                bg: 'gray.50',
+            },
+            tr: {
+                borderColor: 'gray.200',
+                borderWidth: '1px',
+            },
+        },
+    },
+};
+
 const theme = extendTheme({
     components: {
         Button,
@@ -112,6 +130,7 @@ const theme = extendTheme({
         Input,
         ListItem,
         Tooltip,
+        Table,
     },
     fonts: {
         heading: `'Quicksand', sans-serif`,
@@ -133,6 +152,25 @@ const theme = extendTheme({
             fontSize: 'md',
             alignItems: 'center',
             color: 'red.600',
+        },
+        utilityEntry: {
+            fontSize: 'sm',
+            fontWeight: 700,
+        },
+        utilityId: {
+            fontSize: 'sm',
+            fontWeight: 400,
+            color: 'gray.500',
+        },
+        timestamp: {
+            fontSize: 'sm',
+            fontWeight: 400,
+        },
+        tableHeading: {
+            fontSize: 'sm',
+            fontWeight: 700,
+            fontFamily: `'Inter', sans-serif`,
+            textTransform: 'none',
         },
     },
     styles: {


### PR DESCRIPTION
## Overview
- Style the submissions list
- Create a default redirect to /welcome (or /login) for invalid routes e.g. :4545/typo
- Prevent rendering superfluous `<Map>` element for non-map routes

Closes #70 

### Demo
Updated:
![localhost_4545_submissions](https://user-images.githubusercontent.com/38668450/193877908-221e4107-9b10-4f28-b40f-1fa31f31ac93.png)

## Testing Instructions

- scripts/server
- Visit [localhost:4545/submissions](localhost:4545/submissions)
- Check styling
- <s>Check functionality of navigation sidebar</s>
- Check [wireframe](https://www.figma.com/file/tJPZ0lkT5C3SAyS2g2R1aA/IoW---Boundary-Sync-Tool?node-id=342%3A25378)
- Visit a nonexistent page like [localhost:4545/typo](localhost:4545/typo), ensure rerouted to welcome (or login)


## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
