### PR TITLE
Remove browser-dependent `htmlSize` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix react-remove-scroll-bar warning [#29](https://github.com/azavea/iow-boundary-tool/pull/29)
 - Don't move reference image when panning map [#59](https://github.com/azavea/iow-boundary-tool/pull/59)
 - Fix ansible task to use var defined in group_vars [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
+- Remove browser-dependent sizing of input elements [#100](https://github.com/azavea/iow-boundary-tool/pull/100)
 
 ### Deprecated
 

--- a/src/app/src/pages/ForgotPassword.js
+++ b/src/app/src/pages/ForgotPassword.js
@@ -54,8 +54,7 @@ export default function ForgotPassword() {
                         </Text>
                     </Box>
                     <Input
-                        htmlSize={32}
-                        width='auto'
+                        width='xs'
                         bg='white'
                         aria-label='email'
                         placeholder='email'
@@ -69,7 +68,7 @@ export default function ForgotPassword() {
                         }}
                     />
                     <Button
-                        w='320px'
+                        width='xs'
                         variant='cta'
                         onClick={() => forgotPasswordRequest(email)}
                     >

--- a/src/app/src/pages/Login.js
+++ b/src/app/src/pages/Login.js
@@ -51,8 +51,7 @@ export default function Login() {
                 <Text textStyle='apiError'>{errorDetail}</Text>
             </Box>
             <Input
-                htmlSize={32}
-                width='auto'
+                width='xs'
                 bg='white'
                 aria-label='email'
                 placeholder='email'
@@ -64,8 +63,7 @@ export default function Login() {
                 }}
             />
             <Input
-                htmlSize={32}
-                width='auto'
+                width='xs'
                 bg='white'
                 type='password'
                 aria-label='password'
@@ -79,7 +77,7 @@ export default function Login() {
             />
             <VStack spacing={2}>
                 <Button
-                    w='320px'
+                    width='xs'
                     variant='cta'
                     onClick={() => loginRequest(email, password)}
                 >

--- a/src/app/src/pages/ResetPassword.js
+++ b/src/app/src/pages/ResetPassword.js
@@ -87,8 +87,7 @@ export default function ResetPassword() {
     function makePasswordInput(setter, placeholder) {
         return (
             <Input
-                htmlSize={32}
-                width='auto'
+                width='xs'
                 bg='white'
                 aria-label={placeholder}
                 placeholder={placeholder}
@@ -145,7 +144,7 @@ export default function ResetPassword() {
                     {makePasswordInput(setNewPassword1, 'new password')}
                     {makePasswordInput(setNewPassword2, 'new password (again)')}
                     <Button
-                        w='320px'
+                        w='xs'
                         variant='cta'
                         disabled={disableSubmit}
                         onClick={() =>


### PR DESCRIPTION
## Overview
Use of the browser-dependent `htmlSize` attribute was causing poor width agreement between fields and buttons in Safari for the login and reset password screens.

### Demo
In Safari:

**develop**
<img width="514" alt="Screen Shot 2022-09-30 at 3 41 28 PM" src="https://user-images.githubusercontent.com/38668450/193344718-24372109-fd7d-4a49-9583-3dfe75c2749c.png">


**PR**
<img width="493" alt="Screen Shot 2022-09-30 at 3 40 06 PM" src="https://user-images.githubusercontent.com/38668450/193344526-8bdd33b5-03de-4b34-adaa-8ff3588c8f1d.png">

## Testing Instructions

- scripts/server
- Visit /login, /forgot, and /reset in a browser other than Chrome e.g. Safari and ensure widths agree between fields and submit buttons

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
