### PR TITLE
Add RTK Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create Remaining Initial Django Models [#82](https://github.com/azavea/iow-boundary-tool/pull/82)
 - Force users to reset password on first login [#83](https://github.com/azavea/iow-boundary-tool/pull/83)
 - Style submissions list [#99](https://github.com/azavea/iow-boundary-tool/pull/99)
+- Add RTK Query [#101](https://github.com/azavea/iow-boundary-tool/pull/101)
 
 ### Changed
 

--- a/src/app/src/api/api.js
+++ b/src/app/src/api/api.js
@@ -1,0 +1,28 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import apiClient from './client';
+import { BASE_API_URL } from '../constants';
+
+import TAGS from './tags';
+
+const axiosBaseQuery = ({ url, method, data, params }) =>
+    apiClient({
+        url: `${BASE_API_URL}${url}`,
+        method,
+        data,
+        params,
+    })
+        .then(result => ({ data: result.data }))
+        .catch(error => ({
+            error: {
+                status: error.response?.status,
+                data: error.response?.data || error.message,
+            },
+        }));
+
+export default createApi({
+    reducerPath: 'api',
+    baseQuery: axiosBaseQuery,
+    tagTypes: Object.values(TAGS),
+    endpoints: () => ({}),
+});

--- a/src/app/src/api/client.js
+++ b/src/app/src/api/client.js
@@ -1,10 +1,12 @@
 import axios from 'axios';
 
 axios.defaults.baseURL = '/';
+
 // Used to make authenticated HTTP requests to Django
 axios.defaults.xsrfHeaderName = 'X-CSRFToken';
 axios.defaults.xsrfCookieName = 'csrftoken';
-export const API = axios.create({
+
+export default axios.create({
     headers: {
         credentials: 'same-origin',
     },

--- a/src/app/src/api/index.js
+++ b/src/app/src/api/index.js
@@ -1,0 +1,1 @@
+export { default } from './api';

--- a/src/app/src/api/submissions.js
+++ b/src/app/src/api/submissions.js
@@ -1,0 +1,52 @@
+import api from './api';
+import TAGS, {
+    getListTagProvider,
+    getNewItemTagInvalidator,
+    getSingleItemProvider,
+    getUpdateItemTagInvalidator,
+} from './tags';
+
+const submissionApi = api.injectEndpoints({
+    endpoints: build => ({
+        getDraftSubmissions: build.query({
+            query: () => ({
+                url: '/submissions',
+                method: 'GET',
+                params: { type: 'drafts' },
+            }),
+            providesTags: getListTagProvider(TAGS.SUBMISSION),
+        }),
+
+        getSubmissionDetails: build.query({
+            query: id => ({
+                url: `/submissions/${id}`,
+                method: 'GET',
+            }),
+            providesTags: getSingleItemProvider(TAGS.SUBMISSION),
+        }),
+
+        startNewSubmission: build.mutation({
+            query: newSubmission => ({
+                url: '/submissions',
+                method: 'POST',
+                body: newSubmission,
+            }),
+            invalidatesTags: getNewItemTagInvalidator(TAGS.SUBMISSION),
+        }),
+
+        submitSubmission: build.mutation({
+            query: id => ({
+                url: `/submissions/submit/${id}`,
+                method: 'POST',
+            }),
+            invalidatesTags: getUpdateItemTagInvalidator(TAGS.SUBMISSION),
+        }),
+    }),
+});
+
+export const {
+    useGetDraftSubmissionsQuery,
+    useGetSubmissionDetailsQuery,
+    useStartNewSubmissionMutation,
+    useSubmitSubmissionMutation,
+} = submissionApi;

--- a/src/app/src/api/tags.js
+++ b/src/app/src/api/tags.js
@@ -1,0 +1,26 @@
+const TAGS = {
+    SUBMISSION: 'submission',
+
+    LIST_ID: 'list',
+};
+
+export function getListTagProvider(tag) {
+    return results => [
+        ...results.map(({ id }) => ({ tag, id })),
+        { tag, id: TAGS.LIST_ID },
+    ];
+}
+
+export function getSingleItemProvider(tag) {
+    return (result, error, id) => ({ tag, id });
+}
+
+export function getNewItemTagInvalidator(tag) {
+    return () => ({ tag, id: TAGS.LIST_ID });
+}
+
+export function getUpdateItemTagInvalidator(tag) {
+    return (result, error, id) => ({ tag, id });
+}
+
+export default TAGS;

--- a/src/app/src/components/PrivateRoute.js
+++ b/src/app/src/components/PrivateRoute.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 
-import { API } from '../api';
+import apiClient from '../api/client';
 import { API_URLS } from '../constants';
 import { login, setLocationBeforeAuth } from '../store/authSlice';
 
@@ -19,7 +19,8 @@ export default function PrivateRoute({ children }) {
     useEffect(() => {
         if (!signedIn) {
             dispatch(setLocationBeforeAuth(location));
-            API.get(API_URLS.LOGIN)
+            apiClient
+                .get(API_URLS.LOGIN)
                 .then(() => {
                     dispatch(login());
                 })

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -39,11 +39,12 @@ export const PANES = {
     USER_POLYGON: { label: 'user-polygon', zIndex: 490 },
 };
 
+export const BASE_API_URL = 'api';
 export const API_URLS = {
-    LOGIN: 'api/auth/login/',
-    LOGOUT: 'api/auth/logout/',
-    FORGOT: 'api/auth/password/reset/',
-    CONFIRM: 'api/auth/password/reset/confirm/',
+    LOGIN: `${BASE_API_URL}/auth/login/`,
+    LOGOUT: `${BASE_API_URL}/auth/logout/`,
+    FORGOT: `${BASE_API_URL}/auth/password/reset/`,
+    CONFIRM: `${BASE_API_URL}/auth/password/reset/confirm/`,
     RESET: 'confirm_password_reset/reset/',
 };
 

--- a/src/app/src/pages/ForgotPassword.js
+++ b/src/app/src/pages/ForgotPassword.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Box, Button, Input, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 
-import { API } from '../api';
+import apiClient from '../api/client';
 import { API_URLS } from '../constants';
 import LoginForm from '../components/LoginForm';
 import { formatApiError } from '../utils';
@@ -14,7 +14,8 @@ export default function ForgotPassword() {
     const navigate = useNavigate();
 
     const forgotPasswordRequest = () => {
-        API.post(API_URLS.FORGOT, { email })
+        apiClient
+            .post(API_URLS.FORGOT, { email })
             .then(() => {
                 setSuccess(true);
                 setErrorDetail('');

--- a/src/app/src/pages/Login.js
+++ b/src/app/src/pages/Login.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Box, Button, Input, Text, VStack } from '@chakra-ui/react';
 
-import { API } from '../api';
+import apiClient from '../api/client';
 import { API_URLS, API_STATUSES } from '../constants';
 import { login } from '../store/authSlice';
 import LoginForm from '../components/LoginForm';
@@ -17,10 +17,11 @@ export default function Login() {
     const navigate = useNavigate();
 
     const loginRequest = () => {
-        API.post(API_URLS.LOGIN, {
-            email,
-            password,
-        })
+        apiClient
+            .post(API_URLS.LOGIN, {
+                email,
+                password,
+            })
             .then(() => {
                 dispatch(login());
             })

--- a/src/app/src/pages/ResetPassword.js
+++ b/src/app/src/pages/ResetPassword.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Box, Button, Input, Text } from '@chakra-ui/react';
 
-import { API } from '../api';
+import apiClient from '../api/client';
 import { API_URLS } from '../constants';
 import LoginForm from '../components/LoginForm';
 
@@ -45,12 +45,13 @@ export default function ResetPassword() {
     };
 
     const forgotPasswordRequest = () => {
-        API.post(API_URLS.CONFIRM, {
-            uid,
-            token,
-            new_password1: newPassword1,
-            new_password2: newPassword2,
-        })
+        apiClient
+            .post(API_URLS.CONFIRM, {
+                uid,
+                token,
+                new_password1: newPassword1,
+                new_password2: newPassword2,
+            })
             .then(() => {
                 setSuccess(true);
                 setErrorDetail('');
@@ -65,18 +66,23 @@ export default function ResetPassword() {
     // This will require sending a dummy password that will never be valid (too short)
     // in order to get a response including the token or uid fields.
     useEffect(() => {
-        API.post(API_URLS.CONFIRM, {
-            uid,
-            token,
-            new_password1: '!', // too short
-            new_password2: '@',
-        }).catch(apiError => {
-            const errorFields = Object.keys(apiError.response?.data);
-            if (errorFields.includes('token') || errorFields.includes('uid')) {
-                setInvalidToken(true);
-                setSuccess(false);
-            }
-        });
+        apiClient
+            .post(API_URLS.CONFIRM, {
+                uid,
+                token,
+                new_password1: '!', // too short
+                new_password2: '@',
+            })
+            .catch(apiError => {
+                const errorFields = Object.keys(apiError.response?.data);
+                if (
+                    errorFields.includes('token') ||
+                    errorFields.includes('uid')
+                ) {
+                    setInvalidToken(true);
+                    setSuccess(false);
+                }
+            });
     }, [uid, token]);
 
     if ((!uid || !token || invalidToken) && !errorDetail) {

--- a/src/app/src/store/store.js
+++ b/src/app/src/store/store.js
@@ -1,11 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import api from '../api';
 import authReducer from './authSlice';
 import mapReducer from './mapSlice';
 
 export default configureStore({
     reducer: {
+        [api.reducerPath]: api.reducer,
         auth: authReducer,
         map: mapReducer,
     },
+    middleware: getDefaultMiddleware =>
+        getDefaultMiddleware().concat(api.middleware),
 });


### PR DESCRIPTION
## Overview

This PR adds RTK Query endpoints. RTK Query will be used to access to majority of the API.

Closes #86 

## Testing Instructions

- The app should build and load

As of this PR, none of the components are access the API (besides the auth components which don't fit into the RTK Query query/mutation pattern very well). The endpoints in this PR are not real and are there for now as a reference.

## Notes

I moved `/src/api.js` to `/src/api/client.js` and updated the name to `apiClient` where it was used. This should help to distinguish it from the RTK Query "api".

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
