### PR TITLE
Prevent empty Map component from blocking submissions page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ansible task to use var defined in group_vars [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
 - Remove browser-dependent sizing of input elements [#100](https://github.com/azavea/iow-boundary-tool/pull/100)
 - Update AWS_PROFILE env var [#105](https://github.com/azavea/iow-boundary-tool/pull/105)
+- Prevent empty Map component from blocking submissions page from loading [#103](https://github.com/azavea/iow-boundary-tool/pull/103)
 
 ### Deprecated
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,11 +1,5 @@
 import { Box, Flex } from '@chakra-ui/react';
-import {
-    BrowserRouter,
-    Outlet,
-    Navigate,
-    Routes,
-    Route,
-} from 'react-router-dom';
+import { BrowserRouter, Navigate, Routes, Route } from 'react-router-dom';
 
 import './App.css';
 import Login from './pages/Login';
@@ -13,7 +7,6 @@ import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
 import Welcome from './pages/Welcome';
 import Draw from './pages/Draw';
-import Map from './components/Map';
 import Submissions from './pages/Submissions';
 import Sidebar from './components/Sidebar';
 
@@ -26,19 +19,10 @@ const privateRoutes = (
                 <Route path='/draw' element={<Sidebar />} />
             </Routes>
             <Box flex={1} position='relative'>
-                {/* Map routes */}
-                <Map>
-                    <Routes>
-                        <Route path='/welcome' element={<Welcome />} />
-                        <Route path='/draw' element={<Draw />} />
-                    </Routes>
-                </Map>
-                {/* Non-map routes */}
                 <Routes>
+                    <Route path='/welcome' element={<Welcome />} />
+                    <Route path='/draw' element={<Draw />} />
                     <Route path='/submissions' element={<Submissions />} />
-                    {/* Avoid redirecting map routes */}
-                    <Route path='/welcome' element={<Outlet />} />
-                    <Route path='/draw' element={<Outlet />} />
                     <Route
                         path='*'
                         element={<Navigate to='/welcome' replace />}

--- a/src/app/src/pages/Draw.js
+++ b/src/app/src/pages/Draw.js
@@ -1,11 +1,12 @@
 import DrawTools from '../components/DrawTools';
 import Layers from '../components/Layers';
+import Map from '../components/Map';
 
 export default function Draw() {
     return (
-        <>
+        <Map>
             <Layers />
             <DrawTools />
-        </>
+        </Map>
     );
 }

--- a/src/app/src/pages/Welcome.js
+++ b/src/app/src/pages/Welcome.js
@@ -1,11 +1,12 @@
+import Map from '../components/Map';
 import WelcomeModal from '../components/WelcomeModal';
 import { DefaultBasemap } from '../components/Layers/Basemaps';
 
 export default function Welcome() {
     return (
-        <>
+        <Map>
             <WelcomeModal />
             <DefaultBasemap />
-        </>
+        </Map>
     );
 }


### PR DESCRIPTION
## Overview
Updates to #99 described in https://github.com/azavea/iow-boundary-tool/pull/99#discussion_r987314876 prevented the submissions page from loading. Now, this PR restores the original behavior on that branch of moving the `<Map>` component into the `Welcome` and `Draw` pages.


### Notes

Investigation showed that we were re-fetching the map anyway when navigating between welcome and draw. I opened #102 to address this.

## Testing Instructions

- scripts/server
- visit /draw
- visit /welcome
- visit /submissions
- All pages load

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
