### PR TITLE
Update AWS_PROFILE env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't move reference image when panning map [#59](https://github.com/azavea/iow-boundary-tool/pull/59)
 - Fix ansible task to use var defined in group_vars [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
 - Remove browser-dependent sizing of input elements [#100](https://github.com/azavea/iow-boundary-tool/pull/100)
+- Update AWS_PROFILE env var [#105](https://github.com/azavea/iow-boundary-tool/pull/105)
 
 ### Deprecated
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   django:
     image: iow-django
     environment:
-      - AWS_PROFILE=${AWS_PROFILE:-iow-aboutus}
+      - AWS_PROFILE=${AWS_PROFILE:-iow-boundary-tool}
       - POSTGRES_HOST=database
       - POSTGRES_PORT=5432
       - POSTGRES_USER=iow-aboutus


### PR DESCRIPTION
## Overview

There are currently two different AWS profiles specified in the app, `iow-about-us` and `iow-boundary-tool`, and we're moving forward with the latter option since it's used more frequently and better representation of the project. We need to update the `AWS_PROFILE` env var in the dockerfile to match the correct profile in a developer's local AWS credentials file to run `ecsmanage` commands in the django container.

## Testing Instructions

- `scripts/update`
- `scripts/manage ecsmanage showmigrations`
- Confirm could successfully use credentials to run an aws task

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
