### PR TITLE
Add navigation bar and logout

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,5 +1,11 @@
 import { Box, Flex } from '@chakra-ui/react';
-import { BrowserRouter, Navigate, Routes, Route } from 'react-router-dom';
+import {
+    BrowserRouter,
+    Outlet,
+    Navigate,
+    Routes,
+    Route,
+} from 'react-router-dom';
 
 import './App.css';
 import Login from './pages/Login';
@@ -9,11 +15,16 @@ import Welcome from './pages/Welcome';
 import Draw from './pages/Draw';
 import Submissions from './pages/Submissions';
 import Sidebar from './components/Sidebar';
+import NavBar from './components/NavBar';
 
 import PrivateRoute from './components/PrivateRoute';
 
 const privateRoutes = (
     <PrivateRoute>
+        <Routes>
+            <Route path='/welcome' element={<Outlet />} />
+            <Route path='*' element={<NavBar />} />
+        </Routes>
         <Flex>
             <Routes>
                 <Route path='/draw' element={<Sidebar />} />

--- a/src/app/src/components/Map.js
+++ b/src/app/src/components/Map.js
@@ -1,15 +1,23 @@
 import { MapContainer } from 'react-leaflet';
+import { useLocation } from 'react-router-dom';
 
-import { MAP_CENTER, MAP_INITIAL_ZOOM } from '../constants';
+import { MAP_CENTER, MAP_INITIAL_ZOOM, NAVBAR_HEIGHT } from '../constants';
 import MapPanes from './MapPanes';
 
 export default function Map({ children }) {
+    const location = useLocation();
+
+    // Anywhere but welcome activity, deduct height of nav bar
+    const heightExpression = location.pathname.startsWith('/welcome')
+        ? '100vh'
+        : `calc(100vh - ${NAVBAR_HEIGHT}px)`;
+
     return (
         <MapContainer
             center={MAP_CENTER}
             zoom={MAP_INITIAL_ZOOM}
             zoomControl={false}
-            style={{ height: '100vh' }}
+            style={{ height: heightExpression }}
         >
             <MapPanes>{children}</MapPanes>
         </MapContainer>

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -1,0 +1,132 @@
+import {
+    Button,
+    Flex,
+    SimpleGrid,
+    Heading,
+    Icon,
+    IconButton,
+    Select,
+    Spacer,
+    Text,
+} from '@chakra-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { ArrowLeftIcon, CogIcon, LogoutIcon } from '@heroicons/react/outline';
+import apiClient from '../api/client';
+import { API_URLS, NAVBAR_HEIGHT } from '../constants';
+import { logout, setSelectedUtility } from '../store/authSlice';
+
+const NAVBAR_VARIANTS = {
+    DRAW: 'draw',
+    SUBMISSION: 'submission',
+};
+
+export default function NavBar() {
+    const location = useLocation();
+
+    let variant = NAVBAR_VARIANTS.SUBMISSION;
+    if (location.pathname.startsWith('/draw')) {
+        variant = NAVBAR_VARIANTS.DRAW;
+    }
+
+    return (
+        <SimpleGrid
+            columns={3}
+            paddingLeft={10}
+            paddingRight={10}
+            w='100%'
+            h={NAVBAR_HEIGHT}
+            bg='gray.700'
+        >
+            <Flex align='center'>
+                <UtilityControl variant={variant} />
+            </Flex>
+
+            <Flex align='center' justify='center'>
+                <Heading size='md' color='white' ml={6}>
+                    Boundary Sync
+                </Heading>
+            </Flex>
+
+            <Flex align='center' gap={4}>
+                <Spacer />
+                <SettingsButton variant={variant} />
+                <ExitButton variant={variant} />
+            </Flex>
+        </SimpleGrid>
+    );
+}
+
+function SettingsButton({ variant }) {
+    const navigate = useNavigate();
+
+    return variant === NAVBAR_VARIANTS.SUBMISSION ? (
+        <IconButton
+            icon={<Icon as={CogIcon} />}
+            aria-label='Settings'
+            onClick={() => {
+                navigate('/settings');
+            }}
+        />
+    ) : null;
+}
+
+function ExitButton({ variant }) {
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+
+    return variant === NAVBAR_VARIANTS.SUBMISSION ? (
+        <Button
+            onClick={() => {
+                apiClient.post(API_URLS.LOGOUT, {}).then(() => {
+                    dispatch(logout());
+                    navigate('/login');
+                });
+            }}
+            rightIcon={<Icon as={LogoutIcon} />}
+        >
+            Log out
+        </Button>
+    ) : (
+        <Button
+            onClick={() => {
+                navigate('/submissions');
+            }}
+            rightIcon={<Icon as={ArrowLeftIcon} />}
+        >
+            Save and back
+        </Button>
+    );
+}
+
+function UtilityControl({ variant }) {
+    const dispatch = useDispatch();
+
+    // placeholders
+    const utilities = ['Raleigh City of', 'Azavea Test Utility'];
+    const selectedUtility =
+        useSelector(state => state.auth.selectedUtility) || utilities[0];
+
+    return variant === NAVBAR_VARIANTS.SUBMISSION && utilities.length > 1 ? (
+        <Select
+            variant='filled'
+            h='40px'
+            w='250px'
+            value={selectedUtility}
+            onChange={e => {
+                dispatch(setSelectedUtility(e.target.value));
+            }}
+            _focus={{ background: 'white' }}
+        >
+            {utilities.map(u => {
+                return (
+                    <option key={u} value={u}>
+                        {u}
+                    </option>
+                );
+            })}
+        </Select>
+    ) : (
+        <Text textStyle='selectedUtility'>{selectedUtility}</Text>
+    );
+}

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -12,7 +12,6 @@ import {
     Tooltip,
 } from '@chakra-ui/react';
 import {
-    MenuIcon,
     QuestionMarkCircleIcon as HelpIcon,
     PlusIcon,
     EyeIcon,
@@ -37,24 +36,12 @@ export default function Sidebar() {
     return (
         <Container pl={paddingLeft} maxW='xs' bg='gray.700' p={0}>
             <Flex direction='column'>
-                <TitleBar />
                 <Divider />
                 <ReferenceLayers />
                 <Divider />
                 <BasemapLayers />
             </Flex>
         </Container>
-    );
-}
-
-function TitleBar() {
-    return (
-        <Flex align='center' p={4} mb={2}>
-            <Icon color='white' fontSize='2xl' strokeWidth={1} as={MenuIcon} />
-            <Heading size='md' color='white' ml={6}>
-                Boundary Sync
-            </Heading>
-        </Flex>
     );
 }
 

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -30,6 +30,8 @@ export const SIDEBAR_TEXT_TOOLTIP_THRESHOLD = 30;
 
 export const MUNICIPAL_BOUNDARY_LABELS_MIN_ZOOM_LEVEL = 9;
 
+export const NAVBAR_HEIGHT = 68;
+
 // https://leafletjs.com/reference.html#map-mappane
 export const PANES = {
     BASEMAP: { label: 'basemap', zIndex: 200 },

--- a/src/app/src/store/authSlice.js
+++ b/src/app/src/store/authSlice.js
@@ -3,6 +3,8 @@ import { createSlice } from '@reduxjs/toolkit';
 const initialState = {
     signedIn: false,
     locationBeforeAuth: '/welcome',
+    utilities: [],
+    selectedUtility: null,
 };
 
 export const authSlice = createSlice({
@@ -20,9 +22,21 @@ export const authSlice = createSlice({
                 state.locationBeforeAuth = location;
             }
         },
+        setUtilities: (state, { payload: utilities }) => {
+            state.utilities = utilities;
+        },
+        setSelectedUtility: (state, { payload: selectedUtility }) => {
+            state.selectedUtility = selectedUtility;
+        },
     },
 });
 
-export const { login, logout, setLocationBeforeAuth } = authSlice.actions;
+export const {
+    login,
+    logout,
+    setLocationBeforeAuth,
+    setUtilities,
+    setSelectedUtility,
+} = authSlice.actions;
 
 export default authSlice.reducer;

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -209,6 +209,12 @@ const theme = extendTheme({
             fontSize: '16px',
             color: 'gray.700',
         },
+        selectedUtility: {
+            fontFamily: `'Inter', sans-serif`,
+            fontWeight: 400,
+            fontSize: '20px',
+            color: 'white',
+        },
     },
     styles: {
         global: {


### PR DESCRIPTION
## Overview
Implement a navigation bar with logout. Placeholders for selected and available utilities for now.

Closes #85 

### Demo
Submissions activity
![localhost_4545_submissions_42](https://user-images.githubusercontent.com/38668450/194397937-b8c436de-30f0-41c4-8569-49e84ef55152.png)

Draw activity (update: settings icon removed)
![localhost_4545_draw (1)](https://user-images.githubusercontent.com/38668450/194398093-eb408520-ce7c-45e0-95c3-298478b41529.png)

## Notes
Minor nit: the updated wireframe says "Save & Back" but the prior draw tool had "Save and back". I opted for the existing wording "Save and back" to match "Review and submit".

Settings button is just a placeholder.

## Testing Instructions

- scripts/server
- Visit draw activity
  - [x] Ensure static utility label
  - [x] Check styling against [wireframe](https://www.figma.com/file/tJPZ0lkT5C3SAyS2g2R1aA/IoW---Boundary-Sync-Tool?node-id=121%3A2315)
  - [x] Ensure save and back button navigates to submissions
- Visit submissions activity
  - [x] Ensure utility selector
  - [x] Check styling against [wireframe](https://www.figma.com/file/tJPZ0lkT5C3SAyS2g2R1aA/IoW---Boundary-Sync-Tool?node-id=121%3A2315)
  - [x] Ensure log out button is functional
- Verify welcome tool has no nav bar
- Check Draw tool sidebar no longer has its own title bar
- Sanity check draw and welcome tools for regressions

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
