### PR TITLE
Add boundary views and serializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ deployment/ansible/roles/azavea.*
 # Django
 /src/django/static/
 /src/django/data/
+/.venv
 
 # JS
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add navigation bar and logout button [#109](https://github.com/azavea/iow-boundary-tool/pull/109)
 - Style submission detail page [#104](https://github.com/azavea/iow-boundary-tool/pull/104)
 - Add ADR for REST API [#115](https://github.com/azavea/iow-boundary-tool/pull/115)
+- Add boundary list and detail views/serializers [#113](https://github.com/azavea/iow-boundary-tool/pull/113)
 
 ### Changed
 

--- a/src/django/api/management/commands/resetdb.py
+++ b/src/django/api/management/commands/resetdb.py
@@ -6,13 +6,14 @@ from django.core.management.base import BaseCommand
 from api.models import Utility, User
 from api.models.boundary import Boundary
 from api.models.user import Roles
-from api.models.submission import Approval, Submission
 from api.models.state import State
+from api.models.submission import Approval, Submission, Review, Annotation
 
 from ..test_shapes import (
     RALEIGH_FAKE_RECTANGLE,
     RALEIGH_FAKE_TRIANGLE,
     RALEIGH_FAKE_ZIGZAG,
+    POINT_IN_RALEIGH_FAKE_TRIANGLE,
 )
 
 
@@ -23,7 +24,7 @@ class Command(BaseCommand):
         call_command("reset_schema", "--noinput")
         call_command("migrate")
 
-        # Create test utility located in Raleigh.
+        # Create test utilities located in Raleigh.
         test_utility = Utility(pwsid="123456789", name="Azavea Test Utility")
         test_utility.save()
 
@@ -48,15 +49,15 @@ class Command(BaseCommand):
             has_admin_generated_password=False,
             role=Roles.CONTRIBUTOR,
         )
-        contributor.utilities.add(test_utility_1)
-        contributor.utilities.add(test_utility_2)
-        contributor.utilities.add(test_utility_3)
+        contributor.utilities.add(test_utility)
 
         # Create test boundaries and submissions.
         # Use tz-aware datetimes to avoid warnings.
-        boundary_1 = Boundary.objects.create(utility=test_utility_1)
-        boundary_2 = Boundary.objects.create(utility=test_utility_2)
-        boundary_3 = Boundary.objects.create(utility=test_utility_3)
+        boundary_1 = Boundary.objects.create(utility=test_utility)
+        boundary_2 = Boundary.objects.create(utility=test_utility)
+        boundary_3 = Boundary.objects.create(utility=test_utility)
+        boundary_4 = Boundary.objects.create(utility=test_utility)
+        boundary_5 = Boundary.objects.create(utility=test_utility)
 
         # draft
         Submission.objects.create(
@@ -77,8 +78,60 @@ class Command(BaseCommand):
             notes="Notes for the test submission.",
         )
 
-        approved = Submission.objects.create(
+        # reviewing
+        submitted = Submission.objects.create(
             boundary=boundary_3,
+            shape=RALEIGH_FAKE_TRIANGLE,
+            created_at=datetime(2022, 10, 2, hour=4, tzinfo=timezone.utc),
+            created_by=contributor,
+            submitted_at=datetime(2022, 10, 2, hour=6, tzinfo=timezone.utc),
+            submitted_by=contributor,
+            notes="Notes for the test submission.",
+        )
+
+        review = Review.objects.create(
+            submission=submitted,
+            reviewed_by=validator,
+            notes="Notes for the review.",
+            created_at=datetime(2022, 10, 2, hour=10, tzinfo=timezone.utc),
+        )
+
+        Annotation.objects.create(
+            review=review,
+            location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
+            comment="Comment on review",
+            created_at=datetime(2022, 10, 2, hour=10, minute=5, tzinfo=timezone.utc),
+        )
+
+        # needs revision
+        submitted = Submission.objects.create(
+            boundary=boundary_4,
+            shape=RALEIGH_FAKE_TRIANGLE,
+            created_at=datetime(2022, 10, 2, hour=4, tzinfo=timezone.utc),
+            created_by=contributor,
+            submitted_at=datetime(2022, 10, 2, hour=6, tzinfo=timezone.utc),
+            submitted_by=contributor,
+            notes="Notes for the test submission.",
+        )
+
+        review = Review.objects.create(
+            submission=submitted,
+            reviewed_by=validator,
+            reviewed_at=datetime(2022, 10, 2, hour=11, tzinfo=timezone.utc),
+            notes="Notes for the review.",
+            created_at=datetime(2022, 10, 2, hour=10, tzinfo=timezone.utc),
+        )
+
+        Annotation.objects.create(
+            review=review,
+            location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
+            comment="Comment on review",
+            created_at=datetime(2022, 10, 2, hour=10, minute=5, tzinfo=timezone.utc),
+        )
+
+        # approved
+        approved = Submission.objects.create(
+            boundary=boundary_5,
             shape=RALEIGH_FAKE_RECTANGLE,
             created_at=datetime(2022, 10, 1, hour=8, tzinfo=timezone.utc),
             created_by=contributor,

--- a/src/django/api/management/commands/resetdb.py
+++ b/src/django/api/management/commands/resetdb.py
@@ -7,6 +7,7 @@ from api.models import Utility, User
 from api.models.boundary import Boundary
 from api.models.user import Roles
 from api.models.submission import Approval, Submission
+from api.models.state import State
 
 from ..test_shapes import (
     RALEIGH_FAKE_RECTANGLE,
@@ -32,27 +33,34 @@ class Command(BaseCommand):
             password="password",
             has_admin_generated_password=False,
         )
+
         validator = User.objects.create_user(
             email="v1@azavea.com",
             password="password",
             has_admin_generated_password=False,
             role=Roles.VALIDATOR,
         )
+        validator.states.add(State.objects.get(pk='NC'))
+
         contributor = User.objects.create_user(
             email="c1@azavea.com",
             password="password",
             has_admin_generated_password=False,
             role=Roles.CONTRIBUTOR,
         )
-        contributor.utilities.add(test_utility)
+        contributor.utilities.add(test_utility_1)
+        contributor.utilities.add(test_utility_2)
+        contributor.utilities.add(test_utility_3)
 
-        # Create test boundary and submissions.
+        # Create test boundaries and submissions.
         # Use tz-aware datetimes to avoid warnings.
-        boundary = Boundary.objects.create(utility=test_utility)
+        boundary_1 = Boundary.objects.create(utility=test_utility_1)
+        boundary_2 = Boundary.objects.create(utility=test_utility_2)
+        boundary_3 = Boundary.objects.create(utility=test_utility_3)
 
         # draft
         Submission.objects.create(
-            boundary=boundary,
+            boundary=boundary_1,
             shape=RALEIGH_FAKE_ZIGZAG,
             created_at=datetime(2022, 10, 3, hour=15, tzinfo=timezone.utc),
             created_by=contributor,
@@ -60,7 +68,7 @@ class Command(BaseCommand):
 
         # submitted
         Submission.objects.create(
-            boundary=boundary,
+            boundary=boundary_2,
             shape=RALEIGH_FAKE_TRIANGLE,
             created_at=datetime(2022, 10, 2, hour=11, tzinfo=timezone.utc),
             created_by=contributor,
@@ -70,7 +78,7 @@ class Command(BaseCommand):
         )
 
         approved = Submission.objects.create(
-            boundary=boundary,
+            boundary=boundary_3,
             shape=RALEIGH_FAKE_RECTANGLE,
             created_at=datetime(2022, 10, 1, hour=8, tzinfo=timezone.utc),
             created_by=contributor,

--- a/src/django/api/management/test_shapes.py
+++ b/src/django/api/management/test_shapes.py
@@ -61,6 +61,17 @@ RALEIGH_FAKE_TRIANGLE = GEOSGeometry(
 }
 """
 )
+POINT_IN_RALEIGH_FAKE_TRIANGLE = GEOSGeometry(
+    """
+{
+    "type": "Point",
+    "coordinates": [
+        -78.70000000000000,
+        35.80000000000000
+    ]
+}
+    """
+)
 
 
 RALEIGH_FAKE_ZIGZAG = GEOSGeometry(

--- a/src/django/api/models/boundary.py
+++ b/src/django/api/models/boundary.py
@@ -1,8 +1,18 @@
+from enum import Enum
+from django.utils.functional import cached_property
 from django.db import models
 
 from .utility import Utility
 
 __all__ = ["Boundary"]
+
+
+class BOUNDARY_STATUS(Enum):
+    DRAFT = "Draft"
+    SUBMITTED = "Submitted"
+    IN_REVIEW = "In Review"
+    NEEDS_REVISIONS = "Needs Revisions"
+    APPROVED = "Approved"
 
 
 class Boundary(models.Model):
@@ -14,3 +24,42 @@ class Boundary(models.Model):
 
     def __str__(self):
         return f"{self.utility} Boundary"
+
+    @cached_property
+    def last_modified(self):
+        if self.status == BOUNDARY_STATUS.DRAFT:
+            return self.latest_submission.updated_at
+
+        if self.status == BOUNDARY_STATUS.SUBMITTED:
+            return self.latest_submission.submitted_at
+
+        if self.status == BOUNDARY_STATUS.IN_REVIEW:
+            return self.latest_submission.review.created_at
+
+        if self.status == BOUNDARY_STATUS.NEEDS_REVISIONS:
+            return self.latest_submission.review.reviewed_at
+
+        if self.status == BOUNDARY_STATUS.APPROVED:
+            return self.latest_submission.approval.approved_at
+
+    @cached_property
+    def status(self):
+        if self.latest_submission.submitted_at is None:
+            return BOUNDARY_STATUS.DRAFT
+
+        if hasattr(self.latest_submission, 'approval'):
+            return BOUNDARY_STATUS.APPROVED
+
+        if hasattr(self.latest_submission, 'review'):
+            review = self.latest_submission.review
+
+            if review.reviewed_at is None:
+                return BOUNDARY_STATUS.IN_REVIEW
+
+            return BOUNDARY_STATUS.NEEDS_REVISIONS
+
+        return BOUNDARY_STATUS.SUBMITTED
+
+    @cached_property
+    def latest_submission(self):
+        return self.submissions.latest()

--- a/src/django/api/serializers/boundary.py
+++ b/src/django/api/serializers/boundary.py
@@ -1,0 +1,27 @@
+from rest_framework.serializers import (
+    ModelSerializer,
+    CharField,
+    ChoiceField,
+    DateTimeField,
+)
+
+from ..models.boundary import Boundary, BOUNDARY_STATUS
+
+
+class StatusField(ChoiceField):
+    def __init__(self):
+        super().__init__(choices=[status for status in BOUNDARY_STATUS])
+
+    def to_representation(self, status):
+        return status.value
+
+
+class BoundaryListSerializer(ModelSerializer):
+    location = CharField(source='utility.name')
+    pwsid = CharField(source='utility.pwsid')
+    last_modified = DateTimeField()
+    status = StatusField()
+
+    class Meta:
+        model = Boundary
+        fields = ['id', 'location', 'pwsid', 'last_modified', 'status']

--- a/src/django/api/serializers/boundary.py
+++ b/src/django/api/serializers/boundary.py
@@ -6,6 +6,8 @@ from rest_framework.serializers import (
 )
 
 from ..models.boundary import Boundary, BOUNDARY_STATUS
+from ..models.utility import Utility
+from ..models.submission import Submission, Review, Annotation
 
 
 class StatusField(ChoiceField):
@@ -25,3 +27,37 @@ class BoundaryListSerializer(ModelSerializer):
     class Meta:
         model = Boundary
         fields = ['id', 'location', 'pwsid', 'last_modified', 'status']
+
+
+class BoundaryDetailSerializer(ModelSerializer):
+    class UtilitySerializer(ModelSerializer):
+        class Meta:
+            model = Utility
+            fields = ['name', 'pwsid']
+
+    class SubmissionSerializer(ModelSerializer):
+        class ReviewSerializer(ModelSerializer):
+            class AnnotationSerializer(ModelSerializer):
+                class Meta:
+                    model = Annotation
+                    fields = ['location', 'comment', 'resolved']
+
+            annotations = AnnotationSerializer(many=True)
+
+            class Meta:
+                model = Review
+                fields = ['annotations', 'notes']
+
+        review = ReviewSerializer(required=False)
+
+        class Meta:
+            model = Submission
+            fields = ['shape', 'notes', 'review']
+
+    utility = UtilitySerializer()
+    status = StatusField()
+    submission = SubmissionSerializer(source='latest_submission')
+
+    class Meta:
+        model = Boundary
+        fields = ['utility', 'status', 'submission']

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -1,10 +1,14 @@
 from django.urls import include, path
 from rest_framework.urlpatterns import format_suffix_patterns
-from api import views
+
+from .views import Login, Logout
+from .views.boundary import BoundaryListView
 
 urlpatterns = [
-    path("auth/login/", views.Login.as_view()),
-    path("auth/logout/", views.Logout.as_view()),
+    path("auth/login/", Login.as_view()),
+    path("auth/logout/", Logout.as_view()),
     path("auth/", include("dj_rest_auth.urls")),
+    path("boundaries/", BoundaryListView.as_view()),
 ]
+
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -2,13 +2,14 @@ from django.urls import include, path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import Login, Logout
-from .views.boundary import BoundaryListView
+from .views.boundary import BoundaryDetailView, BoundaryListView
 
 urlpatterns = [
     path("auth/login/", Login.as_view()),
     path("auth/logout/", Logout.as_view()),
     path("auth/", include("dj_rest_auth.urls")),
     path("boundaries/", BoundaryListView.as_view()),
+    path("boundaries/<int:id>/", BoundaryDetailView.as_view()),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -1,0 +1,66 @@
+from django.shortcuts import get_object_or_404
+from django.db.models import Prefetch
+
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated
+
+from ..models.user import Roles
+from ..models.boundary import Boundary
+from ..models.submission import Submission
+
+from ..serializers.boundary import BoundaryListSerializer, BoundaryDetailSerializer
+
+
+def get_boundary_queryset_for_user(user):
+    if user.role == Roles.CONTRIBUTOR:
+        return Boundary.objects.filter(utility__in=user.utilities.all())
+
+    if user.role == Roles.VALIDATOR:
+        return Boundary.objects.filter(utility__state__in=user.states.all())
+
+    if user.role == Roles.ADMINISTRATOR:
+        return Boundary.objects.all()
+
+    raise RuntimeError('Invalid role: {}'.format(user.role))
+
+
+class BoundaryListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, format=None):
+        boundaries = get_boundary_queryset_for_user(request.user)
+        boundaries = boundaries.select_related('utility')
+
+        requested_utility_ids = BoundaryListView.get_requested_utility_ids(request)
+        if requested_utility_ids is not None:
+            boundaries = boundaries.filter(utility__in=requested_utility_ids)
+
+        return Response(BoundaryListSerializer(boundaries, many=True).data)
+
+    @staticmethod
+    def get_requested_utility_ids(request):
+        utilities_parameter = request.GET.get('utilities')
+        if utilities_parameter:
+            return utilities_parameter.split(',')
+
+        return None
+
+class BoundaryDetailView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, id, format=None):
+        boundary_set = get_boundary_queryset_for_user(request.user)
+        boundary_set = boundary_set.select_related('utility')
+        boundary_set = boundary_set.prefetch_related(
+            Prefetch(
+                'submissions',
+                queryset=Submission.objects.select_related('review').prefetch_related(
+                    'review__annotations'
+                ),
+            )
+        )
+
+        boundary = get_object_or_404(boundary_set, pk=id)
+
+        return Response(BoundaryDetailSerializer(boundary).data)

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -1,5 +1,5 @@
-from django.shortcuts import get_object_or_404
 from django.db.models import Prefetch
+from django.shortcuts import get_object_or_404
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -45,6 +45,7 @@ class BoundaryListView(APIView):
             return utilities_parameter.split(',')
 
         return None
+
 
 class BoundaryDetailView(APIView):
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## Overview

This PR adds serializers for submissions and a few related objects and views for submissions.

Closes #107 

### Notes

I added a venv folder to the .gitignore so I could install requirements locally.

TODO: Create activity log

## Testing Instructions

* `scripts/manage resetdb` in order to test the validator user, if desired
* Log in as c1@azavea.com
* Go to http://localhost:8181/api/boundaries/
* See list of submissions
  * There should be one for each stage in the submission process
* Pick one of the submissions, go to the details page (i.e. http://localhost:8181/api/boundaries/1)
  * Check that all the relevant details are returned (reviews/annotations/submissions)

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
