### PR TITLE
Configure Amazon SES email support in staging env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ADR for REST API [#115](https://github.com/azavea/iow-boundary-tool/pull/115)
 - Add boundary list and detail views/serializers [#113](https://github.com/azavea/iow-boundary-tool/pull/113) [#135](https://github.com/azavea/iow-boundary-tool/pull/135)
 - Add other state boundaries [#111](https://github.com/azavea/iow-boundary-tool/pull/111)
+- Configure Amazon SES email support in staging env [#118](https://github.com/azavea/iow-boundary-tool/pull/118)
 
 ### Changed
 

--- a/deployment/terraform/app.tf
+++ b/deployment/terraform/app.tf
@@ -123,6 +123,7 @@ resource "aws_ecs_task_definition" "app" {
     django_log_level        = var.django_log_level
     r53_public_hosted_zone  = var.r53_public_hosted_zone
     # aws_storage_bucket_name = aws_s3_bucket.media.id
+    default_from_email = var.default_from_email
 
     port = local.django_container_port
 
@@ -190,6 +191,7 @@ resource "aws_ecs_task_definition" "app_cli" {
     django_log_level       = var.django_log_level
     r53_public_hosted_zone = var.r53_public_hosted_zone
     # aws_storage_bucket_name = aws_s3_bucket.media.id
+    default_from_email = var.default_from_email
 
     project     = var.project
     environment = var.environment

--- a/deployment/terraform/dns.tf
+++ b/deployment/terraform/dns.tf
@@ -92,3 +92,21 @@ resource "aws_route53_record" "wildcard_ipv6" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_record" "ses_verification" {
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "_amazonses.${var.r53_public_hosted_zone}"
+  type    = "TXT"
+  ttl     = "300"
+  records = [aws_ses_domain_identity.app.verification_token]
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count = 3
+
+  zone_id = aws_route53_zone.external.zone_id
+  name    = "${aws_ses_domain_dkim.app.dkim_tokens[count.index]}._domainkey.${var.r53_public_hosted_zone}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${aws_ses_domain_dkim.app.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}

--- a/deployment/terraform/email.tf
+++ b/deployment/terraform/email.tf
@@ -1,0 +1,24 @@
+#
+# SES resources
+#
+resource "aws_ses_domain_identity" "app" {
+  domain = var.r53_public_hosted_zone
+}
+
+resource "aws_ses_domain_dkim" "app" {
+  domain = aws_ses_domain_identity.app.domain
+}
+
+resource "aws_ses_identity_notification_topic" "app_bounce" {
+  topic_arn                = aws_sns_topic.global.arn
+  notification_type        = "Bounce"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}
+
+resource "aws_ses_identity_notification_topic" "app_complaint" {
+  topic_arn                = aws_sns_topic.global.arn
+  notification_type        = "Complaint"
+  identity                 = aws_ses_domain_identity.app.domain
+  include_original_headers = false
+}

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -30,3 +30,26 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy" {
   role       = aws_iam_role.ecs_task_execution_role.name
   policy_arn = var.aws_ecs_task_execution_role_policy_arn
 }
+
+data "aws_iam_policy_document" "scoped_email_sending" {
+  statement {
+    effect = "Allow"
+
+    actions = ["ses:SendEmail", "ses:SendRawEmail"]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ses:FromAddress"
+
+      values = [var.default_from_email]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "scoped_email_sending" {
+  name   = "ses${var.environment}ScopedEmailSendingPolicy"
+  role   = aws_iam_role.ecs_task_role.name
+  policy = data.aws_iam_policy_document.scoped_email_sending.json
+}

--- a/deployment/terraform/task-definitions/app.json.tmpl
+++ b/deployment/terraform/task-definitions/app.json.tmpl
@@ -48,6 +48,10 @@
         "value": "${django_log_level}"
       },
       {
+        "name": "DEFAULT_FROM_EMAIL",
+        "value": "${default_from_email}"
+      },
+      {
         "name": "R53_PUBLIC_HOSTED_ZONE",
         "value": "${r53_public_hosted_zone}"
       }

--- a/deployment/terraform/task-definitions/app_cli.json.tmpl
+++ b/deployment/terraform/task-definitions/app_cli.json.tmpl
@@ -40,6 +40,10 @@
         "value": "${django_log_level}"
       },
       {
+        "name": "DEFAULT_FROM_EMAIL",
+        "value": "${default_from_email}"
+      },
+      {
         "name": "R53_PUBLIC_HOSTED_ZONE",
         "value": "${r53_public_hosted_zone}"
       }

--- a/deployment/terraform/variables.tf
+++ b/deployment/terraform/variables.tf
@@ -277,6 +277,10 @@ variable "django_log_level" {
   type = string
 }
 
+variable "default_from_email" {
+  type = string
+}
+
 variable "aws_ecs_task_execution_role_policy_arn" {
   default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
   type    = string

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -272,7 +272,7 @@ ECSMANAGE_ENVIRONMENTS = {
 
 if ENVIRONMENT == 'Development':
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-    DEFAULT_FROM_EMAIL = 'noreply@iow.test'
 else:
     EMAIL_BACKEND = 'django_amazon_ses.EmailBackend'
-    DEFAULT_FROM_EMAIL = os.getenv('IOW_DEFAULT_FROM_EMAIL')
+
+DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'noreply@staging.iow.azavea.com')

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -6,6 +6,7 @@ django-extensions==3.1.5
 django-simple-history==3.1.1
 django-spa==0.3.6
 django-storages==1.12.3
+django-amazon-ses==4.0.1
 django-watchman==1.3.0
 djangorestframework==3.13.1
 djangorestframework-gis==1.0


### PR DESCRIPTION
## Overview

Adds Terraform resources and configures Django appropriately via [django-amazon-ses](https://github.com/azavea/django-amazon-ses) to send emails from staging env through Amazon SES. Updates the Django `DEFAULT_FROM_EMAIL` to include a default if an environment variable doesn't exist.

- [x] Submit support request to move out of the SES sandbox for staging (confirming language on slack before submitting)

Closes #95 #80

### Demo
<img width="893" alt="Screen Shot 2022-10-10 at 6 23 46 PM" src="https://user-images.githubusercontent.com/36374797/194961671-e96d95e7-f510-4366-a11c-a3bb87a2560b.png">

<img width="980" alt="Screen Shot 2022-10-10 at 6 25 41 PM" src="https://user-images.githubusercontent.com/36374797/194961659-8eaa7a5b-733e-4e61-a30f-9e6a6f78a882.png">

### Notes

- While I set a default from email in Django `SETTINGS`, Terraform still expected a `default_from_email` variable within the `terraform/terrafrom.tfvars` file on S3. While not documented in the git history of this branch, this PR also includes adding the below line to that S3 file for terraform to build:
`default_from_email = "noreply@staging.iow.azavea.com"`

## Testing Instructions

- `scripts/server`
- Navigate to `/login` and select 'Forgot password'
- Confirm email logs to console in development environment
- While in the SES Sandbox we'll need to either create a verified email identity to test sending emails or confirm email sent through the SES dashboard. I created a verified email identity to test and followed [these instructions](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure)
- Create a User in the admin that corresponds to a verified email identity
- Navigate to https://staging.iow.azavea.com/forgot
- Add email to form and click "continue"
- Confirm email sent to inbox of verified email identity or view updated graph in SES dashboard

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
