### PR TITLE
Update dev database configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove browser-dependent sizing of input elements [#100](https://github.com/azavea/iow-boundary-tool/pull/100)
 - Update AWS_PROFILE env var [#105](https://github.com/azavea/iow-boundary-tool/pull/105)
 - Prevent empty Map component from blocking submissions page from loading [#103](https://github.com/azavea/iow-boundary-tool/pull/103)
+- Fix `./scripts/console database` [#121](https://github.com/azavea/iow-boundary-tool/pull/121)
 
 ### Deprecated
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@
 # version : "2.4"
 services:
   database:
-    image: quay.io/azavea/postgis:3-postgres12.4-slim
+    image: postgis/postgis:12-3.1
     environment:
       - POSTGRES_USER=iow-boundary-tool
       - POSTGRES_PASSWORD=iow-boundary-tool
       - POSTGRES_DB=iow-boundary-tool
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "iow-aboutus" ]
+      test: [ "CMD", "pg_isready", "-U", "iow-boundary-tool", "-h", "database" ]
       interval: 3s
       timeout: 3s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       test: [ "CMD", "pg_isready", "-U", "iow-boundary-tool", "-h", "database" ]
       interval: 3s
       timeout: 3s
-      retries: 3
+      retries: 6
 
   app:
     image: node:18-slim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
   database:
     image: quay.io/azavea/postgis:3-postgres12.4-slim
     environment:
-      - POSTGRES_USER=iow-aboutus
-      - POSTGRES_PASSWORD=iow-aboutus
-      - POSTGRES_DB=iow-aboutus
+      - POSTGRES_USER=iow-boundary-tool
+      - POSTGRES_PASSWORD=iow-boundary-tool
+      - POSTGRES_DB=iow-boundary-tool
     healthcheck:
       test: [ "CMD", "pg_isready", "-U", "iow-aboutus" ]
       interval: 3s
@@ -36,9 +36,9 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-iow-boundary-tool}
       - POSTGRES_HOST=database
       - POSTGRES_PORT=5432
-      - POSTGRES_USER=iow-aboutus
-      - POSTGRES_PASSWORD=iow-aboutus
-      - POSTGRES_DB=iow-aboutus
+      - POSTGRES_USER=iow-boundary-tool
+      - POSTGRES_PASSWORD=iow-boundary-tool
+      - POSTGRES_DB=iow-boundary-tool
       - DJANGO_ENV=Development
       - DJANGO_SECRET_KEY=secret
       - DJANGO_LOG_LEVEL=INFO

--- a/scripts/console
+++ b/scripts/console
@@ -31,5 +31,5 @@ if [ -n "$NORMAL_CONTAINER" ]; then
 fi
 
 if [ -n "$DATABASE_CONTAINER" ]; then
-    docker-compose exec database gosu postgres psql -d iow-boundary-tool
+    docker-compose exec database psql -U iow-boundary-tool
 fi


### PR DESCRIPTION
## Overview

Rename the database container to `iow-boundary-tool` to match the rest of the app.
Switch to using PostGIS 3.1 / Postgres 12 version of the standard images rather than the Azavea ones, which is now the new standard. This is the same version as used in staging:

```console
./scripts/manage ecsmanage dbshell -- -c "SELECT PostGIS_Version();"
```

![image](https://user-images.githubusercontent.com/1430060/195424423-f717f775-fbd6-4e32-ae66-46361516bbd8.png)

Closes #98 

### Demo

![image](https://user-images.githubusercontent.com/1430060/195425092-280388fc-725c-4d80-b3de-90fc23c44ee1.png)

## Testing Instructions

- Checkout this branch
- Run `docker compose down` to delete all existing containers
- Run `./scripts/setup`
- Run `./scripts/console database`
  - [x] Ensure you can get in to `psql` and can run queries

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
