### PR TITLE
Load boundary details in draw page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configure Amazon SES email support in staging env [#118](https://github.com/azavea/iow-boundary-tool/pull/118)
 - Wire up Boundary List Page [#122](https://github.com/azavea/iow-boundary-tool/pull/122)
 - Add ReferenceImage views/serializers for image metadata [#114](https://github.com/azavea/iow-boundary-tool/pull/114)
+- Load boundary details in draw page [#139](https://github.com/azavea/iow-boundary-tool/pull/139)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,4 +1,3 @@
-import { Box, Flex } from '@chakra-ui/react';
 import {
     BrowserRouter,
     Outlet,
@@ -14,7 +13,7 @@ import ResetPassword from './pages/ResetPassword';
 import Welcome from './pages/Welcome';
 import Draw from './pages/Draw';
 import Submissions from './pages/Submissions';
-import Sidebar from './components/Sidebar';
+import NotFound from './pages/NotFound';
 import NavBar from './components/NavBar';
 
 import PrivateRoute from './components/PrivateRoute';
@@ -25,22 +24,14 @@ const privateRoutes = (
             <Route path='/welcome' element={<Outlet />} />
             <Route path='*' element={<NavBar />} />
         </Routes>
-        <Flex>
-            <Routes>
-                <Route path='/draw' element={<Sidebar />} />
-            </Routes>
-            <Box flex={1} position='relative'>
-                <Routes>
-                    <Route path='/welcome' element={<Welcome />} />
-                    <Route path='/draw' element={<Draw />} />
-                    <Route path='/submissions/*' element={<Submissions />} />
-                    <Route
-                        path='*'
-                        element={<Navigate to='/welcome' replace />}
-                    />
-                </Routes>
-            </Box>
-        </Flex>
+
+        <Routes>
+            <Route path='/welcome' element={<Welcome />} />
+            <Route path='/draw' element={<NotFound />} />
+            <Route path='/draw/:id' element={<Draw />} />
+            <Route path='/submissions/*' element={<Submissions />} />
+            <Route path='*' element={<Navigate to='/welcome' replace />} />
+        </Routes>
     </PrivateRoute>
 );
 

--- a/src/app/src/api/tags.js
+++ b/src/app/src/api/tags.js
@@ -12,15 +12,15 @@ export function getListTagProvider(tag) {
 }
 
 export function getSingleItemProvider(tag) {
-    return (result, error, id) => ({ tag, id });
+    return (result, error, id) => [{ tag, id }];
 }
 
 export function getNewItemTagInvalidator(tag) {
-    return () => ({ tag, id: TAGS.LIST_ID });
+    return () => [{ tag, id: TAGS.LIST_ID }];
 }
 
 export function getUpdateItemTagInvalidator(tag) {
-    return (result, error, id) => ({ tag, id });
+    return (result, error, id) => [{ tag, id }];
 }
 
 export default TAGS;

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -1,3 +1,6 @@
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
 import { Button, Icon } from '@chakra-ui/react';
 import { ArrowRightIcon } from '@heroicons/react/outline';
 
@@ -9,7 +12,28 @@ import useEditingPolygon from './useEditingPolygon';
 import useGeocoderResult from './useGeocoderResult';
 import useTrackMapZoom from './useTrackMapZoom';
 
-export default function DrawTools() {
+import { setPolygon } from '../../store/mapSlice';
+
+export default function DrawTools({ details }) {
+    const dispatch = useDispatch();
+
+    // Add the polygon indicated by `details` to the state
+    useEffect(() => {
+        if (details) {
+            dispatch(
+                setPolygon({
+                    // endpoint returns lngLat, leaflet needs latLng
+                    points: details.submission.shape.coordinates[0].map(p => [
+                        p[1],
+                        p[0],
+                    ]),
+                    visible: true,
+                    label: details.utility.name,
+                })
+            );
+        }
+    }, [dispatch, details]);
+
     useEditingPolygon();
     useAddPolygonCursor();
     useGeocoderResult();

--- a/src/app/src/components/DrawTools/useAddPolygonCursor.js
+++ b/src/app/src/components/DrawTools/useAddPolygonCursor.js
@@ -3,7 +3,7 @@ import { useMap } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
 import { DomUtil } from 'leaflet';
 
-import { addPolygon } from '../../store/mapSlice';
+import { setPolygon } from '../../store/mapSlice';
 import { generateInitialPolygonPoints } from '../../utils';
 
 export default function useAddPolygonCursor() {
@@ -20,7 +20,7 @@ export default function useAddPolygonCursor() {
 
             map.flyTo(event.latlng);
             dispatch(
-                addPolygon({
+                setPolygon({
                     points: generateInitialPolygonPoints({
                         mapBounds: map.getBounds(),
                         center: event.latlng,

--- a/src/app/src/components/ModalSections/FileUpload.js
+++ b/src/app/src/components/ModalSections/FileUpload.js
@@ -29,7 +29,7 @@ export default function FileUpload({ PreviousButton }) {
             heading='Would you like to add your current map?'
             prevButton={PreviousButton}
             nextButton={
-                <Button variant='cta' onClick={() => navigate('/draw')}>
+                <Button variant='cta' onClick={() => navigate('/draw/3')}>
                     Continue
                 </Button>
             }

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -43,7 +43,7 @@ export default function NavBar() {
             </Flex>
 
             <Flex align='center' justify='center'>
-                <Heading size='md' color='white' ml={6}>
+                <Heading size='md' color='white'>
                     Boundary Sync
                 </Heading>
             </Flex>

--- a/src/app/src/components/Submissions/Detail/DataGrid.js
+++ b/src/app/src/components/Submissions/Detail/DataGrid.js
@@ -15,7 +15,7 @@ export default function DataGrid({ initialMarginTop, title, data }) {
                             </Text>
                             {/* if not a string, accept a React element */}
                             {entry instanceof String ? (
-                                <Text mt={1} textStyle='submissionDetailBody'>
+                                <Text mt={1} textStyle='detail'>
                                     {entry}
                                 </Text>
                             ) : (

--- a/src/app/src/components/Submissions/Detail/Info.js
+++ b/src/app/src/components/Submissions/Detail/Info.js
@@ -36,13 +36,13 @@ export default function Info({ submission }) {
                     'Water system name': utilityName,
                     'Mailing address': (
                         <>
-                            <Text mt={1} textStyle='submissionDetailBody'>
+                            <Text mt={1} textStyle='detail'>
                                 {utilityAddress1}
                             </Text>
-                            <Text mt={1} textStyle='submissionDetailBody'>
+                            <Text mt={1} textStyle='detail'>
                                 {utilityAddress2}
                             </Text>
-                            <Text mt={1} textStyle='submissionDetailBody'>
+                            <Text mt={1} textStyle='detail'>
                                 {cityStateZip}
                             </Text>
                         </>

--- a/src/app/src/components/Submissions/Detail/Map.js
+++ b/src/app/src/components/Submissions/Detail/Map.js
@@ -61,9 +61,7 @@ function SubmissionStatusBar({ submission }) {
                     color='teal.400'
                     boxSize={6}
                 ></Icon>
-                <Text textStyle='submissionDetailBody'>
-                    Your map will be reviewed.
-                </Text>
+                <Text textStyle='detail'>Your map will be reviewed.</Text>
             </HStack>
         </Box>
     );

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -41,7 +41,7 @@ export default function SubmissionsList() {
             <Flex>
                 <Heading size='lg'>Submissions</Heading>
                 <Spacer />
-                <Button mr={4} onClick={() => navigate('/draw')}>
+                <Button mr={4} onClick={() => navigate('/welcome')}>
                     Add map
                 </Button>
             </Flex>

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -1,4 +1,4 @@
-export const MAP_CENTER = [35.7596, -79.0193]; // North Carolina
+export const MAP_CENTER = [35.7938, -78.7232]; // Raleigh, North Carolina
 export const MAP_INITIAL_ZOOM = 13;
 export const INITIAL_POLYGON_SCALE_FACTOR = 0.5;
 
@@ -64,4 +64,11 @@ export const BOUNDARY_STATUS = {
     IN_REVIEW: 'In Review',
     NEEDS_REVISIONS: 'Needs Revisions',
     APPROVED: 'Approved',
+};
+
+// In sync with django.api.models.user.Roles
+export const ROLES = {
+    CONTRIBUTOR: 'C',
+    VALIDATOR: 'V',
+    ADMINISTRATOR: 'A',
 };

--- a/src/app/src/pages/Draw.js
+++ b/src/app/src/pages/Draw.js
@@ -1,12 +1,67 @@
+import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+import { Box, Flex, Spinner } from '@chakra-ui/react';
+
+import NotFound from './NotFound';
 import DrawTools from '../components/DrawTools';
 import Layers from '../components/Layers';
 import Map from '../components/Map';
+import Sidebar from '../components/Sidebar';
+
+import { useGetBoundaryDetailsQuery } from '../api/boundaries';
+import { BOUNDARY_STATUS, ROLES } from '../constants';
+
+const DRAW_MODES = {
+    FULLY_EDITABLE: 'fully_editable',
+    ANNOTATIONS_ONLY: 'annotations_only',
+    READ_ONLY: 'read_only',
+};
 
 export default function Draw() {
+    const user = useSelector(state => state.auth.user);
+    const { id } = useParams();
+
+    const { isFetching, data: details, error } = useGetBoundaryDetailsQuery(id);
+
+    if (isFetching) {
+        return (
+            <Box w='100%' h='100vh'>
+                <Flex direction='column' alignItems='center'>
+                    <Spinner mt={60} />
+                </Flex>
+            </Box>
+        );
+    }
+
+    if (error || typeof details !== 'object') {
+        return <NotFound />;
+    }
+
+    let mode = DRAW_MODES.READ_ONLY;
+
+    if (
+        [BOUNDARY_STATUS.SUBMITTED, BOUNDARY_STATUS.IN_REVIEW].includes(
+            details.status
+        ) &&
+        user.role === ROLES.VALIDATOR
+    ) {
+        mode = DRAW_MODES.ANNOTATIONS_ONLY;
+    } else if (
+        details.status === BOUNDARY_STATUS.DRAFT &&
+        user.role === ROLES.CONTRIBUTOR
+    ) {
+        mode = DRAW_MODES.FULLY_EDITABLE;
+    }
+
     return (
-        <Map>
-            <Layers />
-            <DrawTools />
-        </Map>
+        <Flex>
+            <Sidebar />
+            <Box flex={1} position='relative'>
+                <Map>
+                    <Layers mode={mode} />
+                    <DrawTools mode={mode} details={details} />
+                </Map>
+            </Box>
+        </Flex>
     );
 }

--- a/src/app/src/pages/NotFound.js
+++ b/src/app/src/pages/NotFound.js
@@ -3,7 +3,7 @@ import { Flex, Text } from '@chakra-ui/react';
 export default function NotFound() {
     return (
         <Flex direction='column' bg='gray.50' h='100vh' alignItems='center'>
-            <Text mt={24} textStyle='submissionDetailBody'>
+            <Text mt={24} textStyle='detail'>
                 The requested page was not found.
             </Text>
         </Flex>

--- a/src/app/src/pages/NotFound.js
+++ b/src/app/src/pages/NotFound.js
@@ -1,0 +1,11 @@
+import { Flex, Text } from '@chakra-ui/react';
+
+export default function NotFound() {
+    return (
+        <Flex direction='column' bg='gray.50' h='100vh' alignItems='center'>
+            <Text mt={24} textStyle='submissionDetailBody'>
+                The requested page was not found.
+            </Text>
+        </Flex>
+    );
+}

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -37,7 +37,7 @@ export const mapSlice = createSlice({
     name: 'map',
     initialState,
     reducers: {
-        addPolygon: (state, { payload: newPolygon }) => {
+        setPolygon: (state, { payload: newPolygon }) => {
             state.polygon = {
                 ...DEFAULT_POLYGON,
                 ...newPolygon,
@@ -110,7 +110,7 @@ export const mapSlice = createSlice({
 });
 
 export const {
-    addPolygon,
+    setPolygon,
     updatePolygon,
     deletePolygon,
     togglePolygonVisibility,

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -204,7 +204,7 @@ const theme = extendTheme({
             fontSize: '14px',
             color: 'gray.500',
         },
-        submissionDetailBody: {
+        detail: {
             fontWeight: 400,
             fontSize: '16px',
             color: 'gray.700',

--- a/src/django/api/models/user.py
+++ b/src/django/api/models/user.py
@@ -48,6 +48,8 @@ class EmailAsUsernameUserManager(BaseUserManager):
 
 
 class Roles(models.TextChoices):
+    """In sync with src.app.src.constants.ROLES"""
+
     CONTRIBUTOR = "C"
     VALIDATOR = "V"
     ADMINISTRATOR = "A"


### PR DESCRIPTION

## Overview

Fetch boundary details, and display them in the draw page under a new route `/draw/:id`.
Closes #128 

### Demo
<img width="1497" alt="Screen Shot 2022-10-14 at 12 31 06 PM" src="https://user-images.githubusercontent.com/38668450/195896088-ef727963-3703-4b59-8216-986ba76b083f.png">


### Notes
I had to comment out `providesTags` in the relevant RTK query hook, so I'm hoping @mstone121 could point me in the right direction there.

## Testing Instructions

- `server`
- [x] Ensure 404 page for navigating to `/draw` or `/draw/99999`
- [x] Ensure welcome wizard now directs to `/draw/3` (I chose 3, because 1 was an irregular shape)
- [x] Add map button goes to welcome wizard
- [x] Boundary details are loaded on the draw tool (title, coordinates)
- [ ] Offer a view on the logic for checking roles, but most of that work is #96.

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
