### PR TITLE
Add Activity Log Serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wire up Boundary List Page [#122](https://github.com/azavea/iow-boundary-tool/pull/122)
 - Add ReferenceImage views/serializers for image metadata [#114](https://github.com/azavea/iow-boundary-tool/pull/114)
 - Load boundary details in draw page [#139](https://github.com/azavea/iow-boundary-tool/pull/139)
+- Add Activity Log Serializer [#140](https://github.com/azavea/iow-boundary-tool/pull/140)
 
 ### Changed
 

--- a/src/django/api/serializers/activity_log.py
+++ b/src/django/api/serializers/activity_log.py
@@ -1,0 +1,70 @@
+from rest_framework.serializers import (
+    ModelSerializer,
+    SerializerMethodField,
+    EmailField,
+    DateTimeField,
+)
+
+from ..models import Submission
+
+
+class ActivityDraftedSerializer(ModelSerializer):
+    user = EmailField(source='created_by.email')
+    action = SerializerMethodField()
+    time = DateTimeField(source='created_at')
+    notes = ''
+
+    def get_action(self, value):
+        return 'Drafted'
+
+    class Meta:
+        model = Submission
+        fields = ['user', 'action', 'time']
+        optional_fields = ['annotations_count', 'notes']
+
+
+class ActivitySubmittedSerializer(ActivityDraftedSerializer):
+    def to_representation(self, instance):
+        obj = super().to_representation(instance)
+        obj['action'] = 'Submitted'
+        obj['time'] = instance.submitted_at
+        obj['user'] = instance.submitted_by.email
+        obj['notes'] = instance.notes
+        return obj
+
+
+class ActivityReviewStartedSerializer(ActivityDraftedSerializer):
+    def to_representation(self, instance):
+        obj = super().to_representation(instance)
+        review = instance.review
+        obj['action'] = 'Review Started'
+        obj['time'] = review.created_at
+        obj['user'] = review.reviewed_by.email
+        # Don't show review notes in log until review is complete
+        if hasattr(obj, 'notes'):
+            obj.pop('notes')
+        return obj
+
+
+class ActivityReviewedSerializer(ActivityReviewStartedSerializer):
+    def to_representation(self, instance):
+        obj = super().to_representation(instance)
+        review = instance.review
+        obj['action'] = 'Reviewed'
+        obj['time'] = review.reviewed_at
+        obj['notes'] = review.notes
+        obj['annotations_count'] = review.annotations.count()
+        return obj
+
+
+class ActivityApprovedSerializer(ActivityDraftedSerializer):
+    def to_representation(self, instance):
+        obj = super().to_representation(instance)
+        approval = instance.approval
+        if approval.approved_at:
+            obj['action'] = 'Approved'
+            obj['time'] = approval.approved_at
+            obj['user'] = approval.approved_by.email
+            if hasattr(obj, 'notes'):
+                obj.pop('notes')
+        return obj


### PR DESCRIPTION
## Overview

Adds activity log data as part of the `/boundaries/{id}/` endpoint. Each activity in the log should include the activity type, user taking the action, and time of action as well as any notes and, if an activity is submitting a review, number of annotations. Activity types should be “Drafted", "Submitted", "Reviewed", "Approved".

Closes #125 

### Demo

<img width="899" alt="Screen Shot 2022-10-14 at 6 42 45 PM" src="https://user-images.githubusercontent.com/36374797/195954137-225b6e80-fe7f-48c8-8aa2-0125db02fa6b.png">


## Testing Instructions

I updated the test data to include a handful more submissions to better test the ability to order log events. The below endpoint includes multiple submissions:
http://localhost:8181/api/boundaries/4/

- `scripts/resetdb`
- Login and visit the above api endpoints
- Confirm the activity log is returned as expected
- Login to admin and create a couple various submission activities for a boundary
- Confirm activity log updates correctly and in order for that boundary detail endpoint
- `scripts/test` to confirm no errors

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
