### PR TITLE
Save shape updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load boundary details in draw page [#139](https://github.com/azavea/iow-boundary-tool/pull/139)
 - Let users select utility at login [#142](https://github.com/azavea/iow-boundary-tool/pull/142)
 - Add Activity Log Serializer [#140](https://github.com/azavea/iow-boundary-tool/pull/140)
+- Save shape updates on draw page [#141](https://github.com/azavea/iow-boundary-tool/pull/141)
 
 ### Changed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -28,7 +28,7 @@ const privateRoutes = (
         <Routes>
             <Route path='/welcome' element={<Welcome />} />
             <Route path='/draw' element={<NotFound />} />
-            <Route path='/draw/:id' element={<Draw />} />
+            <Route path='/draw/:boundaryId' element={<Draw />} />
             <Route path='/submissions/*' element={<Submissions />} />
             <Route path='*' element={<Navigate to='/welcome' replace />} />
         </Routes>

--- a/src/app/src/api/boundaries.js
+++ b/src/app/src/api/boundaries.js
@@ -36,7 +36,7 @@ const boundaryApi = api.injectEndpoints({
         updateBoundaryShape: build.mutation({
             query: ({ id, shape }) => ({
                 url: `/boundaries/${id}/shape/`,
-                method: 'POST',
+                method: 'PUT',
                 data: shape,
             }),
         }),

--- a/src/app/src/api/boundaries.js
+++ b/src/app/src/api/boundaries.js
@@ -28,9 +28,17 @@ const boundaryApi = api.injectEndpoints({
             query: newBoundary => ({
                 url: '/boundaries/',
                 method: 'POST',
-                body: newBoundary,
+                data: newBoundary,
             }),
             invalidatesTags: getNewItemTagInvalidator(TAGS.BOUNDARY),
+        }),
+
+        updateBoundaryShape: build.mutation({
+            query: ({ id, shape }) => ({
+                url: `/boundaries/${id}/shape/`,
+                method: 'POST',
+                data: shape,
+            }),
         }),
 
         submitBoundary: build.mutation({
@@ -47,5 +55,6 @@ export const {
     useGetBoundariesQuery,
     useGetBoundaryDetailsQuery,
     useStartNewBoundaryMutation,
+    useUpdateBoundaryShapeMutation,
     useSubmitBoundaryMutation,
 } = boundaryApi;

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { Button, Icon } from '@chakra-ui/react';
 import { ArrowRightIcon } from '@heroicons/react/outline';
@@ -7,14 +7,45 @@ import { ArrowRightIcon } from '@heroicons/react/outline';
 import EditToolbar from './EditToolbar';
 import MapControlButtons from './MapControlButtons';
 
+import { useGetBoundaryDetailsQuery } from '../../api/boundaries';
+import { useBoundaryId, useEndpointToastError } from '../../hooks';
+
 import useAddPolygonCursor from './useAddPolygonCursor';
 import useEditingPolygon from './useEditingPolygon';
 import useGeocoderResult from './useGeocoderResult';
 import useTrackMapZoom from './useTrackMapZoom';
 
 import { setPolygon } from '../../store/mapSlice';
+import { BOUNDARY_STATUS, ROLES } from '../../constants';
+import LoadingModal from '../LoadingModal';
 
-export default function DrawTools({ details }) {
+const DRAW_MODES = {
+    FULLY_EDITABLE: 'fully_editable',
+    ANNOTATIONS_ONLY: 'annotations_only',
+    READ_ONLY: 'read_only',
+};
+
+export default function LoadBoundaryDetails() {
+    const user = useSelector(state => state.auth.user);
+    const id = useBoundaryId();
+
+    const { isFetching, data: details, error } = useGetBoundaryDetailsQuery(id);
+    useEndpointToastError(error);
+
+    if (isFetching) {
+        return <LoadingModal isOpen title='Loading boundary data...' />;
+    }
+
+    if (error || typeof details !== 'object') {
+        return null;
+    }
+
+    const mode = getDrawMode({ status: details.status, userRole: user.role });
+
+    return <DrawTools mode={mode} details={details} />;
+}
+
+function DrawTools({ mode, details }) {
     const dispatch = useDispatch();
 
     // Add the polygon indicated by `details` to the state
@@ -43,6 +74,18 @@ export default function DrawTools({ details }) {
             <MapControlButtons />
         </>
     );
+}
+
+function getDrawMode({ status, userRole }) {
+    if (userRole === ROLES.VALIDATOR && status === BOUNDARY_STATUS.IN_REVIEW) {
+        return DRAW_MODES.ANNOTATIONS_ONLY;
+    }
+
+    if (status === BOUNDARY_STATUS.DRAFT && userRole === ROLES.CONTRIBUTOR) {
+        return DRAW_MODES.FULLY_EDITABLE;
+    }
+
+    return DRAW_MODES.READ_ONLY;
 }
 
 function SaveAndBackButton() {

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -22,11 +22,7 @@ export default function DrawTools({ details }) {
         if (details) {
             dispatch(
                 setPolygon({
-                    // endpoint returns lngLat, leaflet needs latLng
-                    points: details.submission.shape.coordinates[0].map(p => [
-                        p[1],
-                        p[0],
-                    ]),
+                    points: details.submission.shape.coordinates[0],
                     visible: true,
                     label: details.utility.name,
                 })

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -7,11 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { customizePrototypeIcon } from '../../utils';
 import { PANES } from '../../constants';
 import { useUpdateBoundaryShapeMutation } from '../../api/boundaries';
-import {
-    useBoundaryId,
-    useReverseQueue,
-    useTrailingDebounceCallback,
-} from '../../hooks';
+import { useBoundaryId, useTrailingDebounceCallback } from '../../hooks';
 import api from '../../api/api';
 
 const POLYGON_LAYER_OPTIONS = {
@@ -58,20 +54,13 @@ export default function useEditingPolygon() {
     const { polygon, editMode, basemapType } = useSelector(state => state.map);
 
     const [updateShape] = useUpdateBoundaryShapeMutation();
-    const reverseQueue = useReverseQueue({
-        endpointName: 'getBoundaryDetails',
-        queryArgs: id,
-    });
 
     const updatePolygonFromDrawEvent = useTrailingDebounceCallback({
         callback: event => {
-            updateShape({ id, shape: getShapeFromDrawEvent(event) })
-                .unwrap()
-                .then(reverseQueue.clear)
-                .catch(reverseQueue.apply);
+            updateShape({ id, shape: getShapeFromDrawEvent(event) });
         },
         immediateCallback: event => {
-            const { inversePatches } = dispatch(
+            dispatch(
                 api.util.updateQueryData(
                     'getBoundaryDetails',
                     id,
@@ -81,8 +70,6 @@ export default function useEditingPolygon() {
                     }
                 )
             );
-
-            reverseQueue.push(inversePatches);
         },
         interval: 3000,
     });

--- a/src/app/src/components/LoadingModal.js
+++ b/src/app/src/components/LoadingModal.js
@@ -1,0 +1,28 @@
+import {
+    Flex,
+    Modal,
+    ModalBody,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalOverlay,
+    Spinner,
+} from '@chakra-ui/react';
+
+export default function LoadingModal({ isOpen, title }) {
+    return (
+        <Modal isOpen={isOpen} isCentered size='xs'>
+            <ModalOverlay>
+                <ModalContent>
+                    <ModalHeader alignItems='center'>{title ?? ''}</ModalHeader>
+                    <ModalBody>
+                        <Flex direction='column' alignItems='center'>
+                            <Spinner size='xl' />
+                        </Flex>
+                        <ModalFooter />
+                    </ModalBody>
+                </ModalContent>
+            </ModalOverlay>
+        </Modal>
+    );
+}

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -9,7 +9,6 @@ import {
     updateReferenceImage,
 } from './store/mapSlice';
 import { useParams } from 'react-router';
-import api from './api/api';
 
 export function useDialogController() {
     const [isOpen, setIsOpen] = useState(false);
@@ -151,29 +150,6 @@ export function useTrailingDebounceCallback({
         },
         [callback, immediateCallback, interval]
     );
-}
-
-export function useReverseQueue({ queryArgs, endpointName }) {
-    const dispatch = useDispatch();
-
-    const queue = useRef([]);
-
-    const clear = useCallback(() => {
-        queue.current = [];
-    }, []);
-
-    const apply = useCallback(() => {
-        dispatch(
-            api.util.patchQueryData(endpointName, queryArgs, queue.current)
-        );
-        clear();
-    }, [dispatch, queryArgs, endpointName, clear]);
-
-    const push = useCallback(patches => {
-        queue.current = [...patches, ...queue.current];
-    }, []);
-
-    return { queue, clear, apply, push };
 }
 
 export function useEndpointToastError(error, message = 'An error occured') {

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useMap } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
+import { useToast } from '@chakra-ui/react';
 
 import { convertIndexedObjectToArray } from './utils';
 import {
@@ -173,4 +174,19 @@ export function useReverseQueue({ queryArgs, endpointName }) {
     }, []);
 
     return { queue, clear, apply, push };
+}
+
+export function useEndpointToastError(error, message = 'An error occured') {
+    const toast = useToast();
+
+    useEffect(() => {
+        if (error) {
+            toast({
+                title: message,
+                status: 'error',
+                isClosable: true,
+                duration: 5000,
+            });
+        }
+    }, [error, message, toast]);
 }

--- a/src/app/src/hooks.js
+++ b/src/app/src/hooks.js
@@ -7,6 +7,7 @@ import {
     createDefaultReferenceImage,
     updateReferenceImage,
 } from './store/mapSlice';
+import { useParams } from 'react-router';
 
 export function useDialogController() {
     const [isOpen, setIsOpen] = useState(false);
@@ -109,4 +110,8 @@ export function useFilePicker(onChange) {
     };
 
     return openFileDialog;
+}
+
+export function useBoundaryId() {
+    return useParams().boundaryId;
 }

--- a/src/app/src/pages/Draw.js
+++ b/src/app/src/pages/Draw.js
@@ -1,65 +1,18 @@
-import { useSelector } from 'react-redux';
-import { Box, Flex, Spinner } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 
-import NotFound from './NotFound';
 import DrawTools from '../components/DrawTools';
 import Layers from '../components/Layers';
 import Map from '../components/Map';
 import Sidebar from '../components/Sidebar';
 
-import { useGetBoundaryDetailsQuery } from '../api/boundaries';
-import { BOUNDARY_STATUS, ROLES } from '../constants';
-import { useBoundaryId } from '../hooks';
-
-const DRAW_MODES = {
-    FULLY_EDITABLE: 'fully_editable',
-    ANNOTATIONS_ONLY: 'annotations_only',
-    READ_ONLY: 'read_only',
-};
-
 export default function Draw() {
-    const user = useSelector(state => state.auth.user);
-    const id = useBoundaryId();
-
-    const { isFetching, data: details, error } = useGetBoundaryDetailsQuery(id);
-
-    if (isFetching) {
-        return (
-            <Box w='100%' h='100vh'>
-                <Flex direction='column' alignItems='center'>
-                    <Spinner mt={60} />
-                </Flex>
-            </Box>
-        );
-    }
-
-    if (error || typeof details !== 'object') {
-        return <NotFound />;
-    }
-
-    let mode = DRAW_MODES.READ_ONLY;
-
-    if (
-        [BOUNDARY_STATUS.SUBMITTED, BOUNDARY_STATUS.IN_REVIEW].includes(
-            details.status
-        ) &&
-        user.role === ROLES.VALIDATOR
-    ) {
-        mode = DRAW_MODES.ANNOTATIONS_ONLY;
-    } else if (
-        details.status === BOUNDARY_STATUS.DRAFT &&
-        user.role === ROLES.CONTRIBUTOR
-    ) {
-        mode = DRAW_MODES.FULLY_EDITABLE;
-    }
-
     return (
         <Flex>
             <Sidebar />
             <Box flex={1} position='relative'>
                 <Map>
-                    <Layers mode={mode} />
-                    <DrawTools mode={mode} details={details} />
+                    <Layers />
+                    <DrawTools />
                 </Map>
             </Box>
         </Flex>

--- a/src/app/src/pages/Draw.js
+++ b/src/app/src/pages/Draw.js
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-import { useParams } from 'react-router-dom';
 import { Box, Flex, Spinner } from '@chakra-ui/react';
 
 import NotFound from './NotFound';
@@ -10,6 +9,7 @@ import Sidebar from '../components/Sidebar';
 
 import { useGetBoundaryDetailsQuery } from '../api/boundaries';
 import { BOUNDARY_STATUS, ROLES } from '../constants';
+import { useBoundaryId } from '../hooks';
 
 const DRAW_MODES = {
     FULLY_EDITABLE: 'fully_editable',
@@ -19,7 +19,7 @@ const DRAW_MODES = {
 
 export default function Draw() {
     const user = useSelector(state => state.auth.user);
-    const { id } = useParams();
+    const id = useBoundaryId();
 
     const { isFetching, data: details, error } = useGetBoundaryDetailsQuery(id);
 

--- a/src/django/api/exceptions.py
+++ b/src/django/api/exceptions.py
@@ -1,0 +1,13 @@
+from rest_framework.exceptions import APIException
+
+
+class ForbiddenException(APIException):
+    status_code = 403
+    default_detail = 'You are not allowed to perform this action.'
+    default_code = 'forbidden'
+
+
+class BadRequestException(APIException):
+    status_code = 400
+    default_detail = 'There was a problem with your request.'
+    default_code = 'bad_request'

--- a/src/django/api/serializers/__init__.py
+++ b/src/django/api/serializers/__init__.py
@@ -3,3 +3,4 @@ from .user import UserSerializer
 from .utility import UtilitySerializer
 from .state import StateIDSerializer
 from .boundary import BoundaryListSerializer, BoundaryDetailSerializer
+from .shape import ShapeSerializer

--- a/src/django/api/serializers/shape.py
+++ b/src/django/api/serializers/shape.py
@@ -1,0 +1,32 @@
+from rest_framework.serializers import Serializer
+from rest_framework.fields import ListField, FloatField
+from django.contrib.gis.geos import Polygon
+
+
+class ShapeSerializer(Serializer):
+    coordinates = ListField(
+        child=ListField(
+            child=ListField(child=FloatField(), min_length=2, max_length=2),
+            min_length=3,
+        ),
+        min_length=1,
+        max_length=1,
+    )
+
+    def to_internal_value(self, data):
+        validated_data = super().to_internal_value(data)
+        coordinates = validated_data['coordinates']
+
+        if not ShapeSerializer.coordinates_are_closed(coordinates):
+            coordinates = ShapeSerializer.get_closed_coordinates(coordinates)
+
+        return Polygon(*coordinates)
+
+    @staticmethod
+    def coordinates_are_closed(coordinates):
+        return coordinates[0][-1] == coordinates[0][0]
+
+    @staticmethod
+    def get_closed_coordinates(coordinates):
+        coordinates[0].append(coordinates[0][0])
+        return coordinates

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -2,7 +2,7 @@ from django.urls import include, path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import Login, Logout
-from .views.boundary import BoundaryDetailView, BoundaryListView
+from .views.boundary import BoundaryDetailView, BoundaryListView, BoundaryShapeView
 from .views.reference_image import ReferenceImageList, ReferenceImageDetail
 
 urlpatterns = [
@@ -11,6 +11,7 @@ urlpatterns = [
     path("auth/", include("dj_rest_auth.urls")),
     path("boundaries/", BoundaryListView.as_view()),
     path("boundaries/<int:id>/", BoundaryDetailView.as_view()),
+    path("boundaries/<int:id>/shape/", BoundaryShapeView.as_view()),
     path(
         "boundaries/<int:boundary>/reference-images/",
         ReferenceImageList.as_view(),


### PR DESCRIPTION
## Overview

This PR adds functionality that saves a boundary when it is updated.

Updating is debouced with a three second interval. Each update is patched immediately and directly into the RTK query cache. After the three second interval, the latest update is sent to the server. If the server fails, changes are rolled back to the last saved state.

Closes #130 

### Notes

The map is re-rendering on update. I believe this is because a component above the map is using the boundary details query. When the shape is updated, this query is updated, which triggers a re-render. This should be addressed here if possible or in a later card.

## Testing Instructions

- Log in as c1@azavea.com
- Go to http://localhost:4545/draw/1
- Make a few adjustments to the shape, wait 3 seconds, and reload the page
  - [x] Ensure updates were saved
- Repeat with v1@azavea.com and http://localhost:4545/draw/3
  - [ ] Ensure updates were saved

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
