### PR TITLE
Let users select utility at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wire up Boundary List Page [#122](https://github.com/azavea/iow-boundary-tool/pull/122)
 - Add ReferenceImage views/serializers for image metadata [#114](https://github.com/azavea/iow-boundary-tool/pull/114)
 - Load boundary details in draw page [#139](https://github.com/azavea/iow-boundary-tool/pull/139)
+- Let users select utility at login [#142](https://github.com/azavea/iow-boundary-tool/pull/142)
 - Add Activity Log Serializer [#140](https://github.com/azavea/iow-boundary-tool/pull/140)
 
 ### Changed

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -5,16 +5,15 @@ import {
     Heading,
     Icon,
     IconButton,
-    Select,
     Spacer,
-    Text,
 } from '@chakra-ui/react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeftIcon, CogIcon, LogoutIcon } from '@heroicons/react/outline';
 import apiClient from '../api/client';
 import { API_URLS, NAVBAR_HEIGHT } from '../constants';
-import { logout, setUtilityByPwsid } from '../store/authSlice';
+import { logout } from '../store/authSlice';
+import UtilityControl from './UtilityControl';
 
 const NAVBAR_VARIANTS = {
     DRAW: 'draw',
@@ -39,7 +38,7 @@ export default function NavBar() {
             bg='gray.700'
         >
             <Flex align='center'>
-                <UtilityControl variant={variant} />
+                <UtilityControl readOnly={variant === NAVBAR_VARIANTS.DRAW} />
             </Flex>
 
             <Flex align='center' justify='center'>
@@ -96,39 +95,5 @@ function ExitButton({ variant }) {
         >
             Save and back
         </Button>
-    );
-}
-
-function UtilityControl({ variant }) {
-    const dispatch = useDispatch();
-
-    const utilities = useSelector(state => state.auth.user.utilities);
-    const utility = useSelector(state => state.auth.utility);
-
-    if (!utility) {
-        return null;
-    }
-
-    return variant === NAVBAR_VARIANTS.SUBMISSION && utilities?.length > 1 ? (
-        <Select
-            variant='filled'
-            h='40px'
-            w='250px'
-            value={utility.pwsid}
-            onChange={e => {
-                dispatch(setUtilityByPwsid(e.target.value));
-            }}
-            _focus={{ background: 'white' }}
-        >
-            {utilities.map(({ id, pwsid, name }) => {
-                return (
-                    <option key={id} value={pwsid}>
-                        {name}
-                    </option>
-                );
-            })}
-        </Select>
-    ) : (
-        <Text textStyle='selectedUtility'>{utility.name}</Text>
     );
 }

--- a/src/app/src/components/UtilityControl.js
+++ b/src/app/src/components/UtilityControl.js
@@ -1,0 +1,43 @@
+import { Select, Text } from '@chakra-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { setUtilityByPwsid } from '../store/authSlice';
+
+export default function UtilityControl({ readOnly, width = '250px' }) {
+    const dispatch = useDispatch();
+
+    const utilities = useSelector(state => state.auth.user.utilities);
+    let utility = useSelector(state => state.auth.utility);
+
+    if (!utility) {
+        if (utilities?.length) {
+            utility = utilities[0];
+        } else {
+            return null;
+        }
+    }
+
+    return !readOnly && utilities?.length > 1 ? (
+        <Select
+            variant='filled'
+            h='40px'
+            w={width}
+            value={utility.pwsid}
+            onChange={e => {
+                dispatch(setUtilityByPwsid(e.target.value));
+            }}
+            style={{ background: 'white' }}
+            _focus={{ background: 'white' }}
+        >
+            {utilities.map(({ id, pwsid, name }) => {
+                return (
+                    <option key={id} value={pwsid}>
+                        {name}
+                    </option>
+                );
+            })}
+        </Select>
+    ) : (
+        <Text textStyle='selectedUtility'>{utility.name}</Text>
+    );
+}

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -31,6 +31,7 @@ export const SIDEBAR_TEXT_TOOLTIP_THRESHOLD = 30;
 export const MUNICIPAL_BOUNDARY_LABELS_MIN_ZOOM_LEVEL = 9;
 
 export const NAVBAR_HEIGHT = 68;
+export const UTILITY_CONTROL_WIDTH = 320;
 
 // https://leafletjs.com/reference.html#map-mappane
 export const PANES = {

--- a/src/app/src/pages/SelectUtility.js
+++ b/src/app/src/pages/SelectUtility.js
@@ -1,0 +1,63 @@
+import { Button, Text } from '@chakra-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+
+import apiClient from '../api/client';
+import LoginForm from '../components/LoginForm';
+import UtilityControl from '../components/UtilityControl';
+import { logout } from '../store/authSlice';
+
+import { API_URLS } from '../constants';
+
+export default function SelectUtility() {
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+    const locationBeforeAuth = useSelector(
+        state => state.auth.locationBeforeAuth
+    );
+    const destination = locationBeforeAuth || '/welcome';
+    const utilities = useSelector(state => state.auth.user?.utilities);
+    const width = '320px';
+
+    return utilities?.length ? (
+        <LoginForm>
+            <Text textStyle='loginHeader'>Boundary Sync</Text>
+            <Text textStyle='utilitySelectLabel' w={width} pt={2} pl={2}>
+                Select your utility
+            </Text>
+            <UtilityControl readOnly={false} width={width} />
+            <Button
+                variant='cta'
+                width='xs'
+                onClick={() => navigate(destination)}
+            >
+                Proceed
+            </Button>
+        </LoginForm>
+    ) : (
+        <LoginForm>
+            <Text textStyle='loginHeader'>Boundary Sync</Text>
+            <Text
+                textStyle='apiError'
+                textAlign='center'
+                w={width}
+                pt={2}
+                pl={2}
+            >
+                You will need to be assigned a utility to proceed.
+            </Text>
+            <Button
+                variant='cta'
+                width='xs'
+                onClick={() => {
+                    apiClient.post(API_URLS.LOGOUT, {}).then(() => {
+                        dispatch(logout());
+                        navigate('/login');
+                    });
+                }}
+            >
+                Logout
+            </Button>
+        </LoginForm>
+    );
+}

--- a/src/app/src/pages/SelectUtility.js
+++ b/src/app/src/pages/SelectUtility.js
@@ -7,7 +7,12 @@ import LoginForm from '../components/LoginForm';
 import UtilityControl from '../components/UtilityControl';
 import { logout } from '../store/authSlice';
 
-import { API_URLS } from '../constants';
+import {
+    BASE_API_URL,
+    API_URLS,
+    BOUNDARY_STATUS,
+    UTILITY_CONTROL_WIDTH,
+} from '../constants';
 
 export default function SelectUtility() {
     const dispatch = useDispatch();
@@ -17,7 +22,24 @@ export default function SelectUtility() {
     );
     const destination = locationBeforeAuth || '/welcome';
     const utilities = useSelector(state => state.auth.user?.utilities);
-    const width = '320px';
+    const utility = useSelector(state => state.auth.utility);
+    const width = `${UTILITY_CONTROL_WIDTH}px`;
+
+    const navigateAway = () => {
+        apiClient
+            .get(`${BASE_API_URL}/boundaries?utilities=${utility.id}`)
+            .then(({ data: boundaries }) => {
+                const drafts = boundaries.filter(
+                    b => b.status === BOUNDARY_STATUS.DRAFT
+                );
+                if (drafts.length > 0) {
+                    navigate(`/draw/${drafts[0].id}`);
+                } else {
+                    navigate(destination);
+                }
+            })
+            .catch(navigate(destination));
+    };
 
     return utilities?.length ? (
         <LoginForm>
@@ -26,11 +48,7 @@ export default function SelectUtility() {
                 Select your utility
             </Text>
             <UtilityControl readOnly={false} width={width} />
-            <Button
-                variant='cta'
-                width='xs'
-                onClick={() => navigate(destination)}
-            >
+            <Button variant='cta' width='xs' onClick={navigateAway}>
                 Proceed
             </Button>
         </LoginForm>

--- a/src/app/src/store/authSlice.js
+++ b/src/app/src/store/authSlice.js
@@ -1,5 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+import { ROLES } from '../constants';
+
 const initialState = {
     locationBeforeAuth: '/welcome',
     user: false,
@@ -13,7 +15,11 @@ export const authSlice = createSlice({
         login: (state, { payload: user }) => {
             state.user = user;
 
-            if (user.utilities) {
+            // Contributors must choose a utility if there are multiple
+            if (
+                user.utilities &&
+                (user.role !== ROLES.CONTRIBUTOR || user.utilities.length === 1)
+            ) {
                 state.utility = user.utilities[0];
             }
         },

--- a/src/app/src/theme.js
+++ b/src/app/src/theme.js
@@ -215,6 +215,11 @@ const theme = extendTheme({
             fontSize: '20px',
             color: 'white',
         },
+        utilitySelectLabel: {
+            fontFamily: `'Inter', sans-serif`,
+            fontSize: '16px',
+            fontWeight: 600,
+        },
     },
     styles: {
         global: {

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -30,6 +30,10 @@ class BoundarySyncAPITestCase(TestCase):
         test_utility = Utility(pwsid="123456789", name="Azavea Test Utility")
         test_utility.save()
 
+        # Create another test utility.
+        other_utility = Utility(pwsid="OTHERUTIL", name="Other Utility")
+        other_utility.save()
+
         # Create test users.
         cls.administrator = User.objects.create_superuser(
             email="a1@azavea.com",
@@ -52,6 +56,7 @@ class BoundarySyncAPITestCase(TestCase):
             role=Roles.CONTRIBUTOR,
         )
         cls.contributor.utilities.add(test_utility)
+        cls.contributor.utilities.add(other_utility)
 
         # Create test boundaries and submissions.
         # Use tz-aware datetimes to avoid warnings.


### PR DESCRIPTION
## Overview

Allow contributors to select a utility when logging in (assuming there is more than one to choose from.)
Navigate directly to any drafts for that utility.

Closes #124 

### Demo

forthcoming

### Notes
- I didn't use RTK query to fetch the draft boundary in the "Proceed" button action. I tried, but was just burning time, so I quit. Feel free to suggest something more idiomatic. (We're not using RTK query for the rest of the login flow.)
- f9eab1aba8b05548b097f84c775e6ccc704998e6 adds a second test utility for the contributor user to make testing easier. I don't know if we want to merge it -- do we want staging to stay frictionless, i.e. don't have this form show?

## Testing Instructions

- scripts/resetdb
- Login as c1@azavea.com/password
  - [x] Ensure utility picker accepts your choice
  - [x] Navigates to the first draft
  - [ ] Or navigates to your location before login if there is no draft
- Repeat with a user with only one utility (just drop f9eab1aba8b05548b097f84c775e6ccc704998e6 and resetdb)
  - [x] ensure no selector
- Regression test utility selector in submissions page

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
