### PR TITLE
Limit boundary list by contributor's selected utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `Roles` enum an `IntEnum` subclass [#74](https://github.com/azavea/iow-boundary-tool/pull/74)
 - Drop `Role` table and refactor as choice field on User [#117](https://github.com/azavea/iow-boundary-tool/pull/117)
 - Return user information from login endpoint [#136](https://github.com/azavea/iow-boundary-tool/pull/136)
+- Limit boundary list by contributor's selected utility [#148](https://github.com/azavea/iow-boundary-tool/pull/148)
 
 ### Fixed
 

--- a/src/app/src/api/boundaries.js
+++ b/src/app/src/api/boundaries.js
@@ -9,9 +9,10 @@ import TAGS, {
 const boundaryApi = api.injectEndpoints({
     endpoints: build => ({
         getBoundaries: build.query({
-            query: () => ({
+            query: ({ utilities }) => ({
                 url: '/boundaries/',
                 method: 'GET',
+                params: { utilities },
             }),
             providesTags: getListTagProvider(TAGS.BOUNDARY),
         }),

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -26,12 +26,14 @@ import {
     FlagIcon,
     LocationMarkerIcon,
 } from '@heroicons/react/solid';
+import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
 import { heroToChakraIcon } from '../../utils';
 import { useGetBoundariesQuery } from '../../api/boundaries';
 
 import { StatusBadge } from './Badges';
+import { ROLES } from '../../constants';
 
 export default function SubmissionsList() {
     const navigate = useNavigate();
@@ -98,7 +100,16 @@ function TableHeader() {
 }
 
 function TableRows() {
-    const { isFetching, data: boundaries, error } = useGetBoundariesQuery();
+    const user = useSelector(state => state.auth.user);
+    const utilityId = useSelector(state => state.auth.utility?.id);
+
+    const {
+        isFetching,
+        data: boundaries,
+        error,
+    } = useGetBoundariesQuery({
+        utilities: user.role === ROLES.CONTRIBUTOR ? utilityId : undefined,
+    });
 
     if (isFetching) {
         return <LoadingRow />;

--- a/src/app/src/pages/SelectUtility.js
+++ b/src/app/src/pages/SelectUtility.js
@@ -27,7 +27,7 @@ export default function SelectUtility() {
 
     const navigateAway = () => {
         apiClient
-            .get(`${BASE_API_URL}/boundaries?utilities=${utility.id}`)
+            .get(`${BASE_API_URL}/boundaries/?utilities=${utility.id}`)
             .then(({ data: boundaries }) => {
                 const drafts = boundaries.filter(
                     b => b.status === BOUNDARY_STATUS.DRAFT


### PR DESCRIPTION
## Overview
Limit the boundary list to just those pertaining to the contributor's selected utility.

Closes #133

### Demo

https://user-images.githubusercontent.com/38668450/197302576-a480e179-42cb-4ebb-9ff8-0ae8f869c630.mp4


## Testing Instructions

- scripts/server
- Log in as c1@azavea.com to "Other Utility"
- Navigate to submissions
  - [ ] Ensure list is empty
 - Use picker to switch utilities
  - [ ] Ensure list populates
 - Regression test v1@azavea.com has all submissions listed

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
