### PR TITLE
Add CI check for missing migrations in `scripts/lint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Activity Log Serializer [#140](https://github.com/azavea/iow-boundary-tool/pull/140)
 - Save shape updates on draw page [#141](https://github.com/azavea/iow-boundary-tool/pull/141)
 - Wire up boundary details page [#143](https://github.com/azavea/iow-boundary-tool/pull/143) [#152](https://github.com/azavea/iow-boundary-tool/pull/152)
+- Add check for missing migrations [#153](https://github.com/azavea/iow-boundary-tool/pull/153)
 
 ### Changed
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -41,6 +41,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 run --rm --no-deps --entrypoint black django \
                 --skip-string-normalization --check --diff \
                 --extend-exclude migrations .
+
+            GIT_COMMIT="${GIT_COMMIT}" docker-compose \
+                -f docker-compose.yml \
+                -f docker-compose.ci.yml \
+                run --rm --entrypoint python django \
+                manage.py makemigrations --check
         else
             # Lint Django app
             docker-compose \
@@ -51,6 +57,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 run --rm --no-deps --entrypoint black django \
                 --skip-string-normalization --check --diff \
                 --extend-exclude migrations .
+
+            docker-compose \
+                run --rm --entrypoint python django \
+                manage.py makemigrations
         fi
     fi
 fi


### PR DESCRIPTION

## Overview
Add a step to `scripts/lint` that locally, produces missing migrations, and on CI, will exit with a failure code if migrations still need to be made.


### Demo
I expect this very run to fail until rebasing on #152 

### Notes
Omit `--dry-run`, which is often used to avoid actually creating the migrations. Here, like running `black`, just let them be made.

## Testing Instructions

- Make model changes without a migration
- scripts/lint


## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
