### PR TITLE
Add User Permissions per Boundary, Guard Draw Page Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Save reference image metadata on draw page [#144](https://github.com/azavea/iow-boundary-tool/pull/144)
 - Wire up create boundary [#145](https://github.com/azavea/iow-boundary-tool/pull/145)
 - Add Draw page React context [#154](https://github.com/azavea/iow-boundary-tool/pull/154)
+- Add User Permissions per Boundary [#156](https://github.com/azavea/iow-boundary-tool/pull/156)
 
 ### Changed
 
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop `Role` table and refactor as choice field on User [#117](https://github.com/azavea/iow-boundary-tool/pull/117)
 - Return user information from login endpoint [#136](https://github.com/azavea/iow-boundary-tool/pull/136)
 - Limit boundary list by contributor's selected utility [#148](https://github.com/azavea/iow-boundary-tool/pull/148)
+- Guard Draw Page Actions [#156](https://github.com/azavea/iow-boundary-tool/pull/156)
 
 ### Fixed
 

--- a/src/app/src/api/referenceImages.js
+++ b/src/app/src/api/referenceImages.js
@@ -44,13 +44,16 @@ const referenceImagesApi = api.injectEndpoints({
     }),
 });
 
-export function useDebouncedUpdateReferenceImageMutation(boundaryId) {
+export function useDebouncedUpdateReferenceImageMutation(
+    boundaryId,
+    canWrite = false
+) {
     const dispatch = useDispatch();
     const [updateReferenceImage, meta] = useUpdateReferenceImageMutation();
 
     const debouncedUpdate = useTrailingDebounceCallback({
         callback: updatedImage => {
-            updateReferenceImage({ boundaryId, ...updatedImage });
+            canWrite && updateReferenceImage({ boundaryId, ...updatedImage });
         },
         immediateCallback: updatedImage => {
             dispatch(

--- a/src/app/src/api/reviews.js
+++ b/src/app/src/api/reviews.js
@@ -1,4 +1,5 @@
 import api from './api';
+import TAGS, { getUpdateItemTagInvalidator } from './tags';
 
 const reviewApi = api.injectEndpoints({
     endpoints: build => ({
@@ -7,6 +8,7 @@ const reviewApi = api.injectEndpoints({
                 url: `/boundaries/${boundaryId}/review`,
                 method: 'POST',
             }),
+            invalidatesTags: getUpdateItemTagInvalidator(TAGS.BOUNDARY),
         }),
     }),
 });

--- a/src/app/src/components/DrawContext.js
+++ b/src/app/src/components/DrawContext.js
@@ -5,13 +5,7 @@ import LoadingModal from './LoadingModal';
 
 import { useGetBoundaryDetailsQuery } from '../api/boundaries';
 import { useBoundaryId, useEndpointToastError } from '../hooks';
-import { BOUNDARY_STATUS, ROLES } from '../constants';
-
-const DRAW_MODES = {
-    FULLY_EDITABLE: 'fully_editable',
-    ANNOTATIONS_ONLY: 'annotations_only',
-    READ_ONLY: 'read_only',
-};
+import { getBoundaryPermissions } from '../utils';
 
 const DrawContext = createContext();
 
@@ -34,31 +28,19 @@ export default function DrawContextProvider({ children }) {
         return null;
     }
 
-    const mode = getDrawMode({ status: boundary.status, userRole: user.role });
+    const permissions = getBoundaryPermissions({ boundary, user });
 
     return (
-        <DrawContext.Provider value={{ boundary, mode }}>
+        <DrawContext.Provider value={{ boundary, permissions }}>
             {children}
         </DrawContext.Provider>
     );
-}
-
-function getDrawMode({ status, userRole }) {
-    if (userRole === ROLES.VALIDATOR && status === BOUNDARY_STATUS.IN_REVIEW) {
-        return DRAW_MODES.ANNOTATIONS_ONLY;
-    }
-
-    if (status === BOUNDARY_STATUS.DRAFT && userRole === ROLES.CONTRIBUTOR) {
-        return DRAW_MODES.FULLY_EDITABLE;
-    }
-
-    return DRAW_MODES.READ_ONLY;
 }
 
 export function useDrawBoundary() {
     return useContext(DrawContext).boundary;
 }
 
-export function useDrawMode() {
-    return useContext(DrawContext).mode;
+export function useDrawPermissions() {
+    return useContext(DrawContext).permissions;
 }

--- a/src/app/src/components/DrawContext.js
+++ b/src/app/src/components/DrawContext.js
@@ -19,21 +19,25 @@ export default function DrawContextProvider({ children }) {
     const user = useSelector(state => state.auth.user);
     const id = useBoundaryId();
 
-    const { isFetching, data: details, error } = useGetBoundaryDetailsQuery(id);
+    const {
+        isFetching,
+        data: boundary,
+        error,
+    } = useGetBoundaryDetailsQuery(id);
     useEndpointToastError(error);
 
     if (isFetching) {
         return <LoadingModal isOpen title='Loading boundary data...' />;
     }
 
-    if (error || typeof details !== 'object') {
+    if (error || typeof boundary !== 'object') {
         return null;
     }
 
-    const mode = getDrawMode({ status: details.status, userRole: user.role });
+    const mode = getDrawMode({ status: boundary.status, userRole: user.role });
 
     return (
-        <DrawContext.Provider value={{ boundary: details, mode }}>
+        <DrawContext.Provider value={{ boundary, mode }}>
             {children}
         </DrawContext.Provider>
     );

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -33,7 +33,6 @@ export default function DrawTools() {
     return (
         <>
             <EditToolbar />
-            <SaveAndBackButton />
             <SubmitModal
                 isOpen={submitDialogController.isOpen}
                 onClose={submitDialogController.close}
@@ -46,22 +45,6 @@ export default function DrawTools() {
             <ReviewAndSaveButton onClick={submitDialogController.open} />
             <MapControlButtons />
         </>
-    );
-}
-
-function SaveAndBackButton() {
-    return (
-        <Button
-            position='absolute'
-            bottom='16px'
-            left='32px'
-            variant='secondary'
-            zIndex={1000}
-            fontSize='lg'
-            p={6}
-        >
-            Save and back
-        </Button>
     );
 }
 

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -1,6 +1,8 @@
 import { Button, Icon } from '@chakra-ui/react';
 import { ArrowRightIcon } from '@heroicons/react/outline';
 
+import { useDrawPermissions } from '../DrawContext.js';
+
 import EditToolbar from './EditToolbar';
 import MapControlButtons from './MapControlButtons';
 
@@ -29,6 +31,7 @@ export default function DrawTools() {
     const afterSubmitDialogController = useDialogController(
         status === BOUNDARY_STATUS.SUBMITTED
     );
+    const { canWrite } = useDrawPermissions();
 
     return (
         <>
@@ -42,7 +45,9 @@ export default function DrawTools() {
                 isOpen={afterSubmitDialogController.isOpen}
                 onClose={afterSubmitDialogController.close}
             />
-            <ReviewAndSaveButton onClick={submitDialogController.open} />
+            {canWrite && (
+                <ReviewAndSaveButton onClick={submitDialogController.open} />
+            )}
             <MapControlButtons />
         </>
     );

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -1,13 +1,11 @@
 import { Button, Icon } from '@chakra-ui/react';
 import { ArrowRightIcon } from '@heroicons/react/outline';
 
-import { useDrawPermissions } from '../DrawContext.js';
-
 import EditToolbar from './EditToolbar';
 import MapControlButtons from './MapControlButtons';
 
 import { useDialogController } from '../../hooks';
-import { useDrawBoundary } from '../DrawContext';
+import { useDrawPermissions } from '../DrawContext.js';
 
 import useAddPolygonCursor from './useAddPolygonCursor';
 import useEditingPolygon from './useEditingPolygon';
@@ -17,20 +15,15 @@ import useTrackMapZoom from './useTrackMapZoom';
 import SubmitModal from '../SubmitModal';
 import AfterSubmitModal from '../AfterSubmitModal';
 
-import { BOUNDARY_STATUS } from '../../constants';
-
 export default function DrawTools() {
-    const { status } = useDrawBoundary();
-
     useEditingPolygon();
     useAddPolygonCursor();
     useGeocoderResult();
     useTrackMapZoom();
 
     const submitDialogController = useDialogController(false);
-    const afterSubmitDialogController = useDialogController(
-        status === BOUNDARY_STATUS.SUBMITTED
-    );
+    const afterSubmitDialogController = useDialogController(false);
+
     const { canWrite } = useDrawPermissions();
 
     return (

--- a/src/app/src/components/DrawTools/EditToolbar.js
+++ b/src/app/src/components/DrawTools/EditToolbar.js
@@ -35,9 +35,7 @@ const POLYGON_BUTTON_WIDTH = 40;
 export default function EditToolbar() {
     const dispatch = useDispatch();
     const boundary = useDrawBoundary();
-    const { editMode, addPolygonMode, polygonIsVisible } = useSelector(
-        state => state.map
-    );
+    const { editMode, polygonIsVisible } = useSelector(state => state.map);
 
     const confirmDeleteDialogController = useDialogController();
     const editDialogController = useDialogController();
@@ -60,31 +58,7 @@ export default function EditToolbar() {
                 cursor='default'
             >
                 <Flex>
-                    {addPolygonMode ? (
-                        <Button
-                            onClick={() => dispatch(cancelAddPolygon())}
-                            w={POLYGON_BUTTON_WIDTH}
-                        >
-                            Cancel
-                        </Button>
-                    ) : hasShape ? (
-                        <Button
-                            onClick={editDialogController.open}
-                            rightIcon={<Icon as={PencilIcon} />}
-                            variant='toolbar'
-                            minW={POLYGON_BUTTON_WIDTH}
-                        >
-                            {boundary.name}
-                        </Button>
-                    ) : (
-                        <Button
-                            onClick={() => dispatch(startAddPolygon())}
-                            rightIcon={<AddPolygonIcon />}
-                            w={POLYGON_BUTTON_WIDTH}
-                        >
-                            Draw Polygon
-                        </Button>
-                    )}
+                    <PolygonButton openEditDialog={editDialogController.open} />
                     <Divider
                         orientation='vertical'
                         mx={4}
@@ -129,6 +103,48 @@ export default function EditToolbar() {
                 defaultLabel={boundary.name}
             />
         </>
+    );
+}
+
+function PolygonButton({ openEditDialog }) {
+    const dispatch = useDispatch();
+    const boundary = useDrawBoundary();
+    const { addPolygonMode } = useSelector(state => state.map);
+
+    const hasShape = !!boundary.submission?.shape;
+
+    if (addPolygonMode) {
+        return (
+            <Button
+                onClick={() => dispatch(cancelAddPolygon())}
+                w={POLYGON_BUTTON_WIDTH}
+            >
+                Cancel
+            </Button>
+        );
+    }
+
+    if (hasShape) {
+        return (
+            <Button
+                onClick={openEditDialog}
+                rightIcon={<Icon as={PencilIcon} />}
+                variant='toolbar'
+                minW={POLYGON_BUTTON_WIDTH}
+            >
+                {boundary.name}
+            </Button>
+        );
+    }
+
+    return (
+        <Button
+            onClick={() => dispatch(startAddPolygon())}
+            rightIcon={<AddPolygonIcon />}
+            w={POLYGON_BUTTON_WIDTH}
+        >
+            Draw Polygon
+        </Button>
     );
 }
 

--- a/src/app/src/components/DrawTools/EditToolbar.js
+++ b/src/app/src/components/DrawTools/EditToolbar.js
@@ -28,13 +28,14 @@ import {
     toggleEditMode,
     togglePolygonVisibility,
 } from '../../store/mapSlice.js';
-import { useDrawBoundary } from '../DrawContext.js';
+import { useDrawBoundary, useDrawPermissions } from '../DrawContext.js';
 
 const POLYGON_BUTTON_WIDTH = 40;
 
 export default function EditToolbar() {
     const dispatch = useDispatch();
     const boundary = useDrawBoundary();
+    const { canWrite } = useDrawPermissions();
     const { editMode, polygonIsVisible } = useSelector(state => state.map);
 
     const confirmDeleteDialogController = useDialogController();
@@ -80,14 +81,14 @@ export default function EditToolbar() {
                         <EditToolbarButton
                             icon={CursorClickIcon}
                             onClick={() => dispatch(toggleEditMode())}
-                            disabled={!hasShape}
+                            disabled={!canWrite || !hasShape}
                             tooltip='Edit Points'
-                            active={editMode}
+                            active={canWrite && editMode}
                         />
                         <EditToolbarButton
                             icon={TrashIcon}
                             onClick={confirmDeleteDialogController.open}
-                            disabled={!hasShape}
+                            disabled={!canWrite || !hasShape}
                             tooltip='Delete Polygon'
                         />
                     </ButtonGroup>
@@ -109,9 +110,18 @@ export default function EditToolbar() {
 function PolygonButton({ openEditDialog }) {
     const dispatch = useDispatch();
     const boundary = useDrawBoundary();
+    const { canWrite } = useDrawPermissions();
     const { addPolygonMode } = useSelector(state => state.map);
 
     const hasShape = !!boundary.submission?.shape;
+
+    if (!canWrite) {
+        return (
+            <Button variant='toolbar' minW={POLYGON_BUTTON_WIDTH} disabled>
+                {boundary.name}
+            </Button>
+        );
+    }
 
     if (addPolygonMode) {
         return (

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -101,6 +101,8 @@ export default function useEditingPolygon() {
 
             map.on(L.Draw.Event.EDITVERTEX, updatePolygonFromDrawEvent);
 
+            map.fitBounds(featureGroup.getBounds());
+
             return () => {
                 map.off(L.Draw.Event.EDITVERTEX, updatePolygonFromDrawEvent);
 

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -12,7 +12,7 @@ import {
 } from '../../constants';
 import { useUpdateBoundaryShapeMutation } from '../../api/boundaries';
 import { useBoundaryId, useTrailingDebounceCallback } from '../../hooks';
-import { useDrawBoundary } from '../DrawContext';
+import { useDrawBoundary, useDrawPermissions } from '../DrawContext';
 import api from '../../api/api';
 
 customizePrototypeIcon(L.Draw.Polyline.prototype, 'edit-poly-marker');
@@ -50,6 +50,7 @@ export default function useEditingPolygon() {
     const id = useBoundaryId();
 
     const shape = useDrawBoundary().submission?.shape;
+    const { canWrite } = useDrawPermissions();
     const { editMode, basemapType, polygonIsVisible } = useSelector(
         state => state.map
     );
@@ -87,7 +88,7 @@ export default function useEditingPolygon() {
                 }
             );
 
-            if (editMode) {
+            if (canWrite && editMode) {
                 polygonLayer.editing.enable();
             }
 
@@ -109,6 +110,7 @@ export default function useEditingPolygon() {
             };
         }
     }, [
+        canWrite,
         shape,
         polygonIsVisible,
         editMode,

--- a/src/app/src/components/Layers/ReferenceImageLayer.js
+++ b/src/app/src/components/Layers/ReferenceImageLayer.js
@@ -6,7 +6,7 @@ import { customizePrototypeIcon } from '../../utils';
 import { useBoundaryId, useEndpointToastError } from '../../hooks';
 import { useMap } from 'react-leaflet';
 import { useDebouncedUpdateReferenceImageMutation } from '../../api/referenceImages';
-import { useDrawBoundary } from '../DrawContext';
+import { useDrawBoundary, useDrawPermissions } from '../DrawContext';
 
 customizePrototypeIcon(L.DistortHandle.prototype, 'ref-handle');
 customizePrototypeIcon(L.DragHandle.prototype, 'ref-handle');
@@ -25,9 +25,10 @@ export default function ReferenceImageLayer() {
     const boundaryId = useBoundaryId();
     const referenceImageLayers = useRef({});
     const images = useDrawBoundary().reference_images;
+    const { canWrite } = useDrawPermissions();
 
     const [updateReferenceImage, { error }] =
-        useDebouncedUpdateReferenceImageMutation(boundaryId);
+        useDebouncedUpdateReferenceImageMutation(boundaryId, canWrite);
     useEndpointToastError(error);
 
     const visibleImages = useMemo(
@@ -55,6 +56,7 @@ export default function ReferenceImageLayer() {
                     L.BorderAction,
                 ],
                 selected: true,
+                editable: canWrite,
                 mode,
                 corners: corners
                     ? corners.map(convertCornerFromStateFormat)
@@ -97,7 +99,7 @@ export default function ReferenceImageLayer() {
 
             return layer;
         },
-        [updateReferenceImage]
+        [canWrite, updateReferenceImage]
     );
 
     /**

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -74,24 +74,9 @@ function SettingsButton({ variant }) {
 function ExitButton({ variant }) {
     const navigate = useNavigate();
     const dispatch = useDispatch();
-    const user = useSelector(state => state.auth.user);
     const { '*': params } = useParams();
 
     const boundaryId = params.startsWith('draw/') ? params.substring(5) : '';
-
-    const queries = useSelector(state => state.api.queries);
-    let boundary = null;
-    if (`getBoundaryDetails("${boundaryId}")` in queries) {
-        boundary = queries[`getBoundaryDetails("${boundaryId}")`].data;
-    }
-
-    let canWrite = false;
-    let canReview = false;
-    if (user && boundary?.status) {
-        const permissions = getBoundaryPermissions({ boundary, user });
-        canWrite = permissions.canWrite;
-        canReview = permissions.canReview;
-    }
 
     return variant === NAVBAR_VARIANTS.SUBMISSION ? (
         <Button
@@ -110,7 +95,7 @@ function ExitButton({ variant }) {
             onClick={() => navigate(`/submissions/${boundaryId}`)}
             rightIcon={<Icon as={ArrowLeftIcon} />}
         >
-            {canWrite || canReview ? 'Save and back' : 'Back'}
+            Back
         </Button>
     );
 }

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -88,9 +88,7 @@ function ExitButton({ variant }) {
         </Button>
     ) : (
         <Button
-            onClick={() => {
-                navigate('/submissions');
-            }}
+            onClick={() => navigate(-1)}
             rightIcon={<Icon as={ArrowLeftIcon} />}
         >
             Save and back

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -8,7 +8,7 @@ import {
     Spacer,
 } from '@chakra-ui/react';
 import { useDispatch } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeftIcon, CogIcon, LogoutIcon } from '@heroicons/react/outline';
 import apiClient from '../api/client';
 import { API_URLS, NAVBAR_HEIGHT } from '../constants';
@@ -73,6 +73,9 @@ function SettingsButton({ variant }) {
 function ExitButton({ variant }) {
     const navigate = useNavigate();
     const dispatch = useDispatch();
+    const { '*': params } = useParams();
+
+    const boundaryId = params.startsWith('draw/') ? params.substring(5) : '';
 
     return variant === NAVBAR_VARIANTS.SUBMISSION ? (
         <Button
@@ -88,7 +91,7 @@ function ExitButton({ variant }) {
         </Button>
     ) : (
         <Button
-            onClick={() => navigate(-1)}
+            onClick={() => navigate(`/submissions/${boundaryId}`)}
             rightIcon={<Icon as={ArrowLeftIcon} />}
         >
             Save and back

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -29,7 +29,7 @@ import {
     useDebouncedUpdateReferenceImageMutation,
     useUploadReferenceImageMutation,
 } from '../api/referenceImages';
-import { useDrawBoundary } from './DrawContext';
+import { useDrawBoundary, useDrawPermissions } from './DrawContext';
 
 const paddingLeft = 4;
 
@@ -49,6 +49,7 @@ export default function Sidebar() {
 function ReferenceLayers() {
     const boundaryId = useBoundaryId();
     const boundary = useDrawBoundary();
+    const { canWrite } = useDrawPermissions();
 
     const [createReferenceImage, { createReferenceImageError }] =
         useUploadReferenceImageMutation();
@@ -88,6 +89,7 @@ function ReferenceLayers() {
                 leftIcon={<Icon as={PlusIcon} />}
                 mb={4}
                 onClick={openFileDialog}
+                disabled={!canWrite}
             >
                 Upload file
             </Button>

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -29,8 +29,7 @@ import {
     useDebouncedUpdateReferenceImageMutation,
     useUploadReferenceImageMutation,
 } from '../api/referenceImages';
-import { useGetBoundaryDetailsQuery } from '../api/boundaries';
-import CenteredSpinner from './CenteredSpinner';
+import { useDrawBoundary } from './DrawContext';
 
 const paddingLeft = 4;
 
@@ -49,12 +48,7 @@ export default function Sidebar() {
 
 function ReferenceLayers() {
     const boundaryId = useBoundaryId();
-
-    const {
-        data: boundary,
-        isLoading,
-        error,
-    } = useGetBoundaryDetailsQuery(boundaryId);
+    const boundary = useDrawBoundary();
 
     const [createReferenceImage, { createReferenceImageError }] =
         useUploadReferenceImageMutation();
@@ -78,14 +72,6 @@ function ReferenceLayers() {
 
     // TODO support multiple files
     const openFileDialog = useFilePicker(files => files.map(uploadImage));
-
-    if (isLoading) {
-        return <CenteredSpinner />;
-    }
-
-    if (error || !boundary) {
-        return null;
-    }
 
     return (
         <Box ml={paddingLeft} mt={6} mb={6}>

--- a/src/app/src/components/Sidebar.js
+++ b/src/app/src/components/Sidebar.js
@@ -55,7 +55,7 @@ function ReferenceLayers() {
         useUploadReferenceImageMutation();
 
     const [updateReferenceImage, { updateReferenceImageError }] =
-        useDebouncedUpdateReferenceImageMutation(boundaryId);
+        useDebouncedUpdateReferenceImageMutation(boundaryId, canWrite);
 
     useEndpointToastError(
         createReferenceImageError ?? updateReferenceImageError

--- a/src/app/src/components/Submissions/Detail/Detail.js
+++ b/src/app/src/components/Submissions/Detail/Detail.js
@@ -20,14 +20,14 @@ import Info from './Info';
 import Map from './Map';
 import { useEndpointToastError } from '../../../hooks';
 import { useStartReviewMutation } from '../../../api/reviews';
-import { NAVBAR_HEIGHT, ROLES } from '../../../constants';
+import { NAVBAR_HEIGHT } from '../../../constants';
 import { useSelector } from 'react-redux';
-import { heroToChakraIcon } from '../../../utils';
+import { getBoundaryPermissions, heroToChakraIcon } from '../../../utils';
 
 export default function SubmissionDetail() {
     const navigate = useNavigate();
     const { id } = useParams();
-    const userRole = useSelector(state => state.auth.user.role);
+    const user = useSelector(state => state.auth.user);
 
     const {
         data: boundary,
@@ -58,8 +58,7 @@ export default function SubmissionDetail() {
         return null;
     }
 
-    const showApproveButton =
-        userRole === ROLES.VALIDATOR || userRole === ROLES.ADMINISTRATOR;
+    const { canApprove } = getBoundaryPermissions({ boundary, user });
 
     return (
         <VStack
@@ -89,7 +88,7 @@ export default function SubmissionDetail() {
                     />
                 </Flex>
                 <Flex direction='column' w='50%'>
-                    {showApproveButton ? (
+                    {canApprove && (
                         <Button
                             mb={4}
                             alignSelf='flex-end'
@@ -97,7 +96,7 @@ export default function SubmissionDetail() {
                         >
                             Mark approved
                         </Button>
-                    ) : null}
+                    )}
 
                     <Box
                         h='sm'

--- a/src/app/src/pages/Draw.js
+++ b/src/app/src/pages/Draw.js
@@ -8,16 +8,16 @@ import Sidebar from '../components/Sidebar';
 
 export default function Draw() {
     return (
-        <Flex>
-            <Sidebar />
-            <Box flex={1} position='relative'>
-                <Map>
-                    <DrawContextProvider>
+        <DrawContextProvider>
+            <Flex>
+                <Sidebar />
+                <Box flex={1} position='relative'>
+                    <Map>
                         <Layers />
                         <DrawTools />
-                    </DrawContextProvider>
-                </Map>
-            </Box>
-        </Flex>
+                    </Map>
+                </Box>
+            </Flex>
+        </DrawContextProvider>
     );
 }

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -2,6 +2,7 @@ import { Icon } from '@chakra-ui/react';
 import L from 'leaflet';
 
 import {
+    BOUNDARY_STATUS,
     INITIAL_POLYGON_SCALE_FACTOR,
     NC_EAST,
     NC_NORTH,
@@ -10,6 +11,7 @@ import {
     REFERENCE_IMAGE_FILE_EXTENSIONS,
     REFERENCE_IMAGE_MIME_TYPES,
     SHAPE_FILE_EXTENSIONS,
+    ROLES,
 } from './constants';
 
 export function heroToChakraIcon(icon) {
@@ -122,4 +124,39 @@ export function fileIsShapeFile(file) {
     return SHAPE_FILE_EXTENSIONS.some(extension =>
         file.name.endsWith(extension)
     );
+}
+
+export function getBoundaryPermissions({ boundary, user }) {
+    const permissions = {
+        canWrite: false,
+        canReview: false,
+        canApprove: false,
+    };
+
+    const status = boundary?.status;
+    const role = user?.role;
+
+    if (!status || !role) {
+        return permissions;
+    }
+
+    if (role === ROLES.ADMINISTRATOR) {
+        permissions.canWrite = true;
+        permissions.canReview = true;
+        permissions.canApprove = true;
+    }
+
+    if (role === ROLES.CONTRIBUTOR && status === BOUNDARY_STATUS.DRAFT) {
+        permissions.canWrite = true;
+    }
+
+    if (
+        role === ROLES.VALIDATOR &&
+        [BOUNDARY_STATUS.SUBMITTED, BOUNDARY_STATUS.IN_REVIEW].includes(status)
+    ) {
+        permissions.canReview = true;
+        permissions.canApprove = true;
+    }
+
+    return permissions;
 }


### PR DESCRIPTION
## Overview

Adds a `useDrawPermissions` hook which returns if the current user `canWrite`, `canReview`, or `canApprove` the current boundary. Guards actions for uploading reference images, editing the shape, to only when the user `canWrite`. Shows appropriate navigation button in the Boundary Detail page based on permissions.

Also fixes an issue where hitting back from the Draw page after getting there from the Boundary Detail would take the user to the Boundary List instead of the Boundary Detail.

Also removes the extraneous Save and Back button on the Draw/Map, since now we have one in the NavBar.

Also centers the boundary on Draw Page load.

Builds atop #154
Closes #96 
Closes #166

### Demo

https://user-images.githubusercontent.com/1430060/198140019-bdeb5806-3756-4190-b854-62d94ea7b10b.mp4

### Notes

Should we make the `DrawContext` a `BoundaryContext` and have it be available to Boundary Detail Page as well?

## Testing Instructions

- Check out this branch and `update` and `resetdb` and `server`
- Go to http://localhost:4545/ and login as c1@azavea.com
  - [x] Ensure you can edit the Draft
  - [x] Ensure you can view, but not edit the other submissions
- Log out, log back in as v1@azavea.com
  - [x] Ensure you can Start a Review for the submitted boundary
  - [x] Ensure you can Continue a Review for the in review boundary
  - [x] Ensure you see an Approve button for both boundaries
  - [x] Ensure you can view, but not edit any submission

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
