### PR TITLE
Fix add polygon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update AWS_PROFILE env var [#105](https://github.com/azavea/iow-boundary-tool/pull/105)
 - Prevent empty Map component from blocking submissions page from loading [#103](https://github.com/azavea/iow-boundary-tool/pull/103)
 - Fix `./scripts/console database` [#121](https://github.com/azavea/iow-boundary-tool/pull/121)
+- Fix add polygon [#169](https://github.com/azavea/iow-boundary-tool/pull/169)
 
 ### Deprecated
 

--- a/src/app/src/components/DrawTools/EditToolbar.js
+++ b/src/app/src/components/DrawTools/EditToolbar.js
@@ -23,7 +23,7 @@ import DeletePolygonConfirmModal from './DeletePolygonConfirmModal.js';
 import { useDialogController } from '../../hooks.js';
 import EditPolygonModal from './EditPolygonModal.js';
 import {
-    cancelAddPolygon,
+    stopAddPolygon,
     startAddPolygon,
     toggleEditMode,
     togglePolygonVisibility,
@@ -126,7 +126,7 @@ function PolygonButton({ openEditDialog }) {
     if (addPolygonMode) {
         return (
             <Button
-                onClick={() => dispatch(cancelAddPolygon())}
+                onClick={() => dispatch(stopAddPolygon())}
                 w={POLYGON_BUTTON_WIDTH}
             >
                 Cancel

--- a/src/app/src/components/DrawTools/useAddPolygonCursor.js
+++ b/src/app/src/components/DrawTools/useAddPolygonCursor.js
@@ -7,6 +7,7 @@ import { generateInitialPolygonPoints } from '../../utils';
 import { useUpdateBoundaryShapeMutation } from '../../api/boundaries';
 import { useBoundaryId, useEndpointToastError } from '../../hooks';
 import api from '../../api/api';
+import { stopAddPolygon } from '../../store/mapSlice';
 
 export default function useAddPolygonCursor() {
     const map = useMap();
@@ -44,7 +45,7 @@ export default function useAddPolygonCursor() {
                     }
                 )
             );
-
+            dispatch(stopAddPolygon());
             updateShape({ id, shape: polygon });
         },
         [map, dispatch, id, updateShape]

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -42,6 +42,7 @@ function styleMidpointElement(element) {
 
 function getShapeFromDrawEvent(event) {
     return {
+        type: 'Polygon',
         coordinates: [
             event.poly.getLatLngs()[0].map(point => [point.lng, point.lat]),
         ],

--- a/src/app/src/store/mapSlice.js
+++ b/src/app/src/store/mapSlice.js
@@ -21,7 +21,7 @@ export const mapSlice = createSlice({
         startAddPolygon: state => {
             state.addPolygonMode = true;
         },
-        cancelAddPolygon: state => {
+        stopAddPolygon: state => {
             state.addPolygonMode = false;
         },
         toggleEditMode: state => {
@@ -54,7 +54,7 @@ export const mapSlice = createSlice({
 export const {
     togglePolygonVisibility,
     startAddPolygon,
-    cancelAddPolygon,
+    stopAddPolygon,
     toggleEditMode,
     toggleLayer,
     setBasemapType,

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -40,10 +40,10 @@ export function generateInitialPolygonPoints({ mapBounds, center }) {
     const southWest = polygonBounds.getSouthWest();
 
     return [
-        [northWest.lat, northWest.lng],
-        [northEast.lat, northEast.lng],
-        [southEast.lat, southEast.lng],
-        [southWest.lat, southWest.lng],
+        [northWest.lng, northWest.lat],
+        [northEast.lng, northEast.lat],
+        [southEast.lng, southEast.lat],
+        [southWest.lng, southWest.lat],
     ];
 }
 


### PR DESCRIPTION
## Overview

This PR addresses a few issues with the add polygon feature:
- The initial polygon wasn't loading because its lat and lng were reversed.
- The UI stays in add polygon mode after selecting a location

Closes #167 

## Testing Instructions

* Logout
* Go to http://localhost:4545
* Login as c1@azavea.com
* Select other utility
* Click through to draw page
- [x] Ensure add polygon works as expected

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
