### PR TITLE
Handle boundaries with no shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wire up create boundary [#145](https://github.com/azavea/iow-boundary-tool/pull/145)
 - Add Draw page React context [#154](https://github.com/azavea/iow-boundary-tool/pull/154)
 - Add User Permissions per Boundary [#156](https://github.com/azavea/iow-boundary-tool/pull/156)
+- Handle boundaries with no shape [#173](https://github.com/azavea/iow-boundary-tool/pull/173)
 
 ### Changed
 

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -5,7 +5,7 @@ import EditToolbar from './EditToolbar';
 import MapControlButtons from './MapControlButtons';
 
 import { useDialogController } from '../../hooks';
-import { useDrawPermissions } from '../DrawContext.js';
+import { useDrawBoundary, useDrawPermissions } from '../DrawContext.js';
 
 import useAddPolygonCursor from './useAddPolygonCursor';
 import useEditingPolygon from './useEditingPolygon';
@@ -47,6 +47,8 @@ export default function DrawTools() {
 }
 
 function ReviewAndSaveButton({ onClick }) {
+    const hasShape = !!useDrawBoundary().submission?.shape;
+
     return (
         <Button
             position='absolute'
@@ -58,6 +60,9 @@ function ReviewAndSaveButton({ onClick }) {
             p={6}
             rightIcon={<Icon as={ArrowRightIcon} />}
             onClick={onClick}
+            isDisabled={!hasShape}
+            _disabled={{ opacity: 0.4, cursor: 'not-allowed' }}
+            _hover={!hasShape ? { opacity: 0.7 } : {}}
         >
             Review and submit
         </Button>

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -50,7 +50,7 @@ function ReviewAndSaveButton({ onClick }) {
     return (
         <Button
             position='absolute'
-            bottom='16px'
+            bottom='32px'
             right='32px'
             variant='cta'
             zIndex={1000}

--- a/src/app/src/components/DrawTools/useAddPolygonCursor.js
+++ b/src/app/src/components/DrawTools/useAddPolygonCursor.js
@@ -26,6 +26,7 @@ export default function useAddPolygonCursor() {
             }
 
             const polygon = {
+                type: 'Polygon',
                 coordinates: [
                     generateInitialPolygonPoints({
                         mapBounds: map.getBounds(),

--- a/src/app/src/components/Submissions/Detail/Map.js
+++ b/src/app/src/components/Submissions/Detail/Map.js
@@ -31,6 +31,7 @@ import {
 
 export default function Map({ boundary, startReview }) {
     const StatusBar = useSubmissionStatusBar(boundary);
+    const shape = boundary.submission?.shape;
 
     return (
         <>
@@ -47,7 +48,7 @@ export default function Map({ boundary, startReview }) {
                 <MapPanes>
                     <DefaultBasemap />
                     <MapButtons boundary={boundary} startReview={startReview} />
-                    <Polygon shape={boundary.submission.shape} />
+                    {shape && <Polygon shape={boundary.submission.shape} />}
                 </MapPanes>
             </MapContainer>
             {StatusBar}
@@ -56,6 +57,8 @@ export default function Map({ boundary, startReview }) {
 }
 
 function MapButtons({ boundary, startReview }) {
+    const shape = boundary.submission?.shape;
+
     return (
         <Box position='absolute' zIndex={1000} top={22} w='100%'>
             <Flex justify='space-evenly'>
@@ -68,17 +71,19 @@ function MapButtons({ boundary, startReview }) {
                         Email
                     </a>
                 </MapButton>
-                <MapButton
-                    icon={DownloadIcon}
-                    onClick={() =>
-                        downloadData(
-                            JSON.stringify(boundary.submission.shape),
-                            getBoundaryShapeFilename(boundary)
-                        )
-                    }
-                >
-                    Download
-                </MapButton>
+                {shape && (
+                    <MapButton
+                        icon={DownloadIcon}
+                        onClick={() =>
+                            downloadData(
+                                JSON.stringify(boundary.submission.shape),
+                                getBoundaryShapeFilename(boundary)
+                            )
+                        }
+                    >
+                        Download
+                    </MapButton>
+                )}
             </Flex>
         </Box>
     );


### PR DESCRIPTION
## Overview

A boundary initially has no shape. This PR updates the UI to handle this situation.
- Review and Submit button is disable with no boundary
- On the submission details page, if there is no shape for the submission, the map will be empty and there will be no download button.

This PR also fixes an issue where an added and unmodified boundary makes the details page unloadable.

Closes #163 

### Notes

#163 requests that the "Save and back" button be disabled. This was renamed to just "Back" #156 so the NavBar wouldn't need to know about the current boundary. Disabling it here would require the same functionality so this change is not included. 

## Testing Instructions

- http://localhost:4545
- Login as c1@azavea.com
- Select "Other utility" as utility
- Don't draw a shape
- The "Review and Submit" button should be disabled.
- Refreshing the page should return the draw page to the same state
- Clicking back takes you to the details page without error
- There should be no download button
- Click edit boundary
- Draw a boundary
- Refresh page and check that everything loads correctly

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
