### PR TITLE
Fix view submission details link destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `./scripts/console database` [#121](https://github.com/azavea/iow-boundary-tool/pull/121)
 - Fix add polygon [#169](https://github.com/azavea/iow-boundary-tool/pull/169)
 - Fix user authentication [#170](https://github.com/azavea/iow-boundary-tool/pull/170)
+- Fix view submission details link destination [#174](https://github.com/azavea/iow-boundary-tool/pull/174)
 
 ### Deprecated
 

--- a/src/app/src/components/AfterSubmitModal.js
+++ b/src/app/src/components/AfterSubmitModal.js
@@ -16,11 +16,13 @@ import {
 import { DownloadIcon, LogoutIcon } from '@heroicons/react/outline';
 import { CheckCircleIcon } from '@heroicons/react/solid';
 
+import { useBoundaryId } from '../hooks';
 import { logout } from '../store/authSlice';
 
-export default function AfterSubmitModal({ isOpen, onClose, details }) {
+export default function AfterSubmitModal({ isOpen, onClose }) {
     const dispatch = useDispatch();
     const navigate = useNavigate();
+    const id = useBoundaryId();
 
     return (
         <Modal
@@ -64,7 +66,7 @@ export default function AfterSubmitModal({ isOpen, onClose, details }) {
                         <Button
                             variant='secondary'
                             onClick={() => {
-                                navigate('/submissions/');
+                                navigate(`/submissions/${id}/`);
                             }}
                         >
                             View submission status

--- a/src/app/src/components/AfterSubmitModal.js
+++ b/src/app/src/components/AfterSubmitModal.js
@@ -17,12 +17,15 @@ import { DownloadIcon, LogoutIcon } from '@heroicons/react/outline';
 import { CheckCircleIcon } from '@heroicons/react/solid';
 
 import { useBoundaryId } from '../hooks';
+import { downloadData, getBoundaryShapeFilename } from '../utils';
 import { logout } from '../store/authSlice';
+import { useDrawBoundary } from './DrawContext';
 
 export default function AfterSubmitModal({ isOpen, onClose }) {
     const dispatch = useDispatch();
     const navigate = useNavigate();
     const id = useBoundaryId();
+    const boundary = useDrawBoundary();
 
     return (
         <Modal
@@ -74,7 +77,12 @@ export default function AfterSubmitModal({ isOpen, onClose }) {
                         <Button
                             variant='secondary'
                             leftIcon={<Icon as={DownloadIcon} />}
-                            onClick={() => {}}
+                            onClick={() => {
+                                downloadData(
+                                    JSON.stringify(boundary.submission.shape),
+                                    getBoundaryShapeFilename(boundary)
+                                );
+                            }}
                         >
                             Download file
                         </Button>

--- a/src/app/src/components/DrawContext.js
+++ b/src/app/src/components/DrawContext.js
@@ -13,14 +13,10 @@ export default function DrawContextProvider({ children }) {
     const user = useSelector(state => state.auth.user);
     const id = useBoundaryId();
 
-    const {
-        isFetching,
-        data: boundary,
-        error,
-    } = useGetBoundaryDetailsQuery(id);
+    const { isLoading, data: boundary, error } = useGetBoundaryDetailsQuery(id);
     useEndpointToastError(error);
 
-    if (isFetching) {
+    if (isLoading) {
         return <LoadingModal isOpen title='Loading boundary data...' />;
     }
 


### PR DESCRIPTION
## Overview

This PR updates the "View Submission Details" link to point to the details rather than list page.

Bonus:
- Wires up download data button on after-submit modal
- Updates draw context so child components are not reset on tag invalidate

Closes #165 

## Testing Instructions

- http://localhost:4545
- Log in as c1@azavea.com
- Select Other Utility
- Draw a boundary
- Submit the boundary
- Click "Download file" on the "It's In" modal and check that the geojson looks correct
- Click "View submission details"
- Ensure that you are now on the submission details page for the new boundary

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
