### PR TITLE
Add "Needs Revisions" test submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add User Permissions per Boundary [#156](https://github.com/azavea/iow-boundary-tool/pull/156)
 - Handle boundaries with no shape [#173](https://github.com/azavea/iow-boundary-tool/pull/173)
 - Add annotation support [#176](https://github.com/azavea/iow-boundary-tool/pull/176)
+- Add "Needs Revision" test submission [#177](https://github.com/azavea/iow-boundary-tool/pull/177)
 
 ### Changed
 

--- a/src/django/api/tests.py
+++ b/src/django/api/tests.py
@@ -95,6 +95,10 @@ class BoundarySyncAPITestCase(TestCase):
             utility=test_utility,
             name="Boundary 5",
         )
+        cls.boundary_6 = Boundary.objects.create(
+            utility=test_utility,
+            name="Boundary 6",
+        )
 
         # Submissions activities should follow
         # Draft-->Submission-->Approved/Revisions flow
@@ -133,6 +137,12 @@ class BoundarySyncAPITestCase(TestCase):
             created_by=cls.contributor,
         )
 
+        submission_6 = Submission.objects.create(
+            boundary=cls.boundary_6,
+            shape=RALEIGH_FAKE_ZIGZAG,
+            created_by=cls.contributor,
+        )
+
         # submitted
         Submission.objects.filter(pk=submission_2.pk).update(
             submitted_at=datetime.now(tz=timezone.utc),
@@ -158,6 +168,12 @@ class BoundarySyncAPITestCase(TestCase):
             notes="Notes for the test submission.",
         )
 
+        Submission.objects.filter(pk=submission_6.pk).update(
+            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_by=cls.contributor,
+            notes="Notes for the test submission.",
+        )
+
         # reviewing
         review_submission_3 = Review.objects.create(
             submission=submission_3,
@@ -168,6 +184,13 @@ class BoundarySyncAPITestCase(TestCase):
 
         review_submission_4 = Review.objects.create(
             submission=submission_4,
+            reviewed_by=cls.validator,
+            notes="Notes for the review.",
+            created_at=datetime.now(tz=timezone.utc),
+        )
+
+        review_submission_6 = Review.objects.create(
+            submission=submission_6,
             reviewed_by=cls.validator,
             notes="Notes for the review.",
             created_at=datetime.now(tz=timezone.utc),
@@ -187,6 +210,13 @@ class BoundarySyncAPITestCase(TestCase):
             created_at=datetime.now(tz=timezone.utc),
         )
 
+        Annotation.objects.create(
+            review=review_submission_6,
+            location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
+            comment="Comment on review",
+            created_at=datetime.now(tz=timezone.utc),
+        )
+
         # needs revision
         Review.objects.filter(pk=review_submission_4.pk).update(
             reviewed_at=datetime.now(tz=timezone.utc),
@@ -194,17 +224,23 @@ class BoundarySyncAPITestCase(TestCase):
             notes="Final notes for the review.",
         )
 
+        Review.objects.filter(pk=review_submission_6.pk).update(
+            reviewed_at=datetime.now(tz=timezone.utc),
+            reviewed_by=cls.validator,
+            notes="Final notes for the review.",
+        )
+
         # new submission draft
 
-        resubmission_4 = Submission.objects.create(
-            boundary=cls.boundary_4,
+        resubmission_6 = Submission.objects.create(
+            boundary=cls.boundary_6,
             shape=RALEIGH_FAKE_TRIANGLE,
             created_by=cls.contributor,
         )
 
         # re-submit for review
 
-        Submission.objects.filter(pk=resubmission_4.pk).update(
+        Submission.objects.filter(pk=resubmission_6.pk).update(
             submitted_at=datetime.now(tz=timezone.utc),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
@@ -212,7 +248,7 @@ class BoundarySyncAPITestCase(TestCase):
 
         # approved
         Approval.objects.create(
-            submission=resubmission_4,
+            submission=resubmission_6,
             approved_at=datetime.now(tz=timezone.utc),
             approved_by=cls.validator,
         )


### PR DESCRIPTION
## Overview

This PR adds test data for a "Needs Revisions" submission.

Closes #157 

### Notes

I converted submission 4 into the "Needs Revisions" submission and made the new submission, 6, the reviewed, re-submitted, approved submission.

## Testing Instructions

- `./scripts/resetdb`
- Go to submissions list for Azavea Test Utility
- See all statuses represented in the list

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
