### PR TITLE
Provide pre-commit hook to run format script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: local
+  hooks:
+    - id: format
+      name: format
+      entry: scripts/format
+      language: script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for uploading files [#175](https://github.com/azavea/iow-boundary-tool/pull/175)
 - Add unapproving to data model [#178](https://github.com/azavea/iow-boundary-tool/pull/178)
 - Add ability to submit reviews [#181](https://github.com/azavea/iow-boundary-tool/pull/181)
+- Add format script and pre-commit hook [#179](https://github.com/azavea/iow-boundary-tool/pull/179)
 - Add ability to resubmit boundaries [#185](https://github.com/azavea/iow-boundary-tool/pull/185)
 - Add support for approving/unapproving boundaries [#186](https://github.com/azavea/iow-boundary-tool/pull/186)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Municipal data can be downloaded with a script:
 ./scripts/fetch-data
 ```
 
+A pre-commit hook that runs the format script before any commit will be
+installed but can always be ignored with `git commit --no-verify`.
+
 #### Development
 
 Rebuild Docker images and run application.

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -11,7 +11,7 @@ DIR="$(dirname "${0}")/../"
 function usage() {
     echo -n \
         "Usage: $(basename "$0")
-Update environment variables file.
+Update environment variables file and install pre-commit hooks.
 "
 }
 
@@ -27,5 +27,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         fi
 
         popd
+
+        if [[ -z "${CI}" ]]; then
+            python3 -m pip install pre-commit
+            pre-commit install
+        fi
     fi
 fi

--- a/scripts/format
+++ b/scripts/format
@@ -20,6 +20,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        # Format JavaScript app
+        docker-compose \
+            run --rm --no-TTY --entrypoint yarn app \
+            prettier --loglevel warn --write src/
+
         # Format Django app
 
         # Get a list of changed ".py" files and trim "src/django"

--- a/scripts/format
+++ b/scripts/format
@@ -30,26 +30,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Get a list of changed ".py" files and trim "src/django"
         changed_files=$(git status --porcelain | grep ".py" | awk -F'src/django/' '{print $2}' | xargs)
         if [[ -n "${changed_files}" ]]; then
-            # Run isort --check-only before fixing to ensure a failure code is emitted
-            if ! docker-compose \
-                run --rm --no-TTY --no-deps --entrypoint isort django ${changed_files} --check-only; then
-
-                docker-compose \
-                    run --rm --no-TTY --no-deps --entrypoint isort django ${changed_files}
-            fi
-            # Run black with --check before fixing to ensure a failure code is emitted
-            if ! docker-compose \
-                run --rm --no-TTY --no-deps --entrypoint black django \
-                --skip-string-normalization \
-                --extend-exclude migrations ${changed_files} \
-                --quiet --check; then
-
-                docker-compose \
-                    run --rm --no-TTY --no-deps --entrypoint black django \
-                    --skip-string-normalization \
-                    --extend-exclude migrations \
-                    --quiet ${changed_files}
-            fi
+            docker-compose \
+                run --rm --no-TTY --no-deps --entrypoint ./format.sh django \
+                ${changed_files}
         fi
     fi
 fi

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Disable "double quote to prevent globbing and word splitting"
+# ${changed_files} is a list that needs to be split on words 
+# shellcheck disable=SC2086
+
+set -e
+
+if [[ -n "${IOW_BOUNDARY_TOOL_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+
+Run formatters on the project's code
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Format Django app
+
+        # Get a list of changed ".py" files and trim "src/django"
+        changed_files=$(git status --porcelain | grep ".py" | awk -F'src/django/' '{print $2}' | xargs)
+        if [[ -n "${changed_files}" ]]; then
+            # Run isort --check-only before fixing to ensure a failure code is emitted
+            if ! docker-compose \
+                run --rm --no-TTY --no-deps --entrypoint isort django ${changed_files} --check-only; then
+
+                docker-compose \
+                    run --rm --no-TTY --no-deps --entrypoint isort django ${changed_files}
+            fi
+            # Run black with --check before fixing to ensure a failure code is emitted
+            if ! docker-compose \
+                run --rm --no-TTY --no-deps --entrypoint black django \
+                --skip-string-normalization \
+                --extend-exclude migrations ${changed_files} \
+                --quiet --check; then
+
+                docker-compose \
+                    run --rm --no-TTY --no-deps --entrypoint black django \
+                    --skip-string-normalization \
+                    --extend-exclude migrations \
+                    --quiet ${changed_files}
+            fi
+        fi
+    fi
+fi

--- a/scripts/lint
+++ b/scripts/lint
@@ -24,6 +24,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         # Lint JavaScript
         docker-compose \
+            run --rm --entrypoint yarn app prettier --check src/
+
+        docker-compose \
             run --rm --entrypoint ./node_modules/.bin/eslint \
             app src/ --ext .js --ext .jsx
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -54,13 +54,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 --exclude settings.py,manage.py,*.pyc,api/migrations/*
 
             docker-compose \
+                run --rm --no-deps --entrypoint isort django . --check
+
+            docker-compose \
                 run --rm --no-deps --entrypoint black django \
                 --skip-string-normalization --check --diff \
                 --extend-exclude migrations .
 
             docker-compose \
                 run --rm --entrypoint python django \
-                manage.py makemigrations
+                manage.py makemigrations --check --dry-run
         fi
     fi
 fi

--- a/src/app/.prettierrc
+++ b/src/app/.prettierrc
@@ -1,10 +1,18 @@
 {
     "arrowParens": "avoid",
     "bracketSpacing": true,
+    "bracketSameLine": false,
     "htmlWhitespaceSensitivity": "css",
     "insertPragma": false,
-    "jsxBracketSameLine": false,
     "jsxSingleQuote": true,
+    "overrides": [
+        {
+            "files": "*.css",
+            "options": {
+                "parser": "css"
+            }
+        }
+    ],
     "parser": "babel",
     "printWidth": 80,
     "proseWrap": "always",

--- a/src/app/src/App.css
+++ b/src/app/src/App.css
@@ -70,12 +70,14 @@
     font-weight: bold;
     font-size: var(--chakra-fontSizes-sm);
     color: var(--chakra-colors-purple-900);
-    text-shadow: 0 0 0.2em var(--chakra-colors-purple-50), 0 0 0.2em var(--chakra-colors-purple-50);
+    text-shadow: 0 0 0.2em var(--chakra-colors-purple-50),
+        0 0 0.2em var(--chakra-colors-purple-50);
 }
 
 .muni-label-light {
     color: var(--chakra-colors-purple-50);
-    text-shadow: 0 0 0.2em var(--chakra-colors-purple-900), 0 0 0.2em var(--chakra-colors-purple-900);
+    text-shadow: 0 0 0.2em var(--chakra-colors-purple-900),
+        0 0 0.2em var(--chakra-colors-purple-900);
 }
 
 .annotation-popup-div .leaflet-popup-content-wrapper {

--- a/src/app/src/App.test.js
+++ b/src/app/src/App.test.js
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+    const { getByText } = render(<App />);
+    const linkElement = getByText(/learn react/i);
+    expect(linkElement).toBeInTheDocument();
 });

--- a/src/app/src/index.css
+++ b/src/app/src/index.css
@@ -1,13 +1,13 @@
 body {
-  margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+        'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+        'Helvetica Neue', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+        monospace;
 }

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -1,11 +1,12 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from rest_framework.authtoken.models import TokenProxy
-from .models.user import User, Utility
-from .models.state import State
+
 from .models.boundary import Boundary
-from .models.submission import Submission, Approval, Review, Annotation
 from .models.reference_image import ReferenceImage
+from .models.state import State
+from .models.submission import Annotation, Approval, Review, Submission
+from .models.user import User, Utility
 
 
 class EmailAsUsernameUserAdmin(UserAdmin):

--- a/src/django/api/fields.py
+++ b/src/django/api/fields.py
@@ -1,9 +1,9 @@
-import os
-import fiona
 import json
+import os
 import tempfile
-
 from pathlib import Path
+
+import fiona
 from django.contrib.gis.geos import GEOSGeometry
 from rest_framework.fields import FileField
 from rest_framework.serializers import ValidationError

--- a/src/django/api/models/__init__.py
+++ b/src/django/api/models/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa: F401
-from .user import User, EmailAsUsernameUserManager, Roles
-from .utility import Utility
-from .state import State
 from .boundary import Boundary
-from .submission import Submission, Approval, Review, Annotation
 from .reference_image import ReferenceImage
+from .state import State
+from .submission import Annotation, Approval, Review, Submission
+from .user import EmailAsUsernameUserManager, Roles, User
+from .utility import Utility

--- a/src/django/api/models/boundary.py
+++ b/src/django/api/models/boundary.py
@@ -1,6 +1,7 @@
 from enum import Enum
-from django.utils.functional import cached_property
+
 from django.db import models
+from django.utils.functional import cached_property
 
 from .utility import Utility
 

--- a/src/django/api/models/state.py
+++ b/src/django/api/models/state.py
@@ -1,6 +1,6 @@
-from django.db import models
 from django.contrib.gis.db import models as gis_models
 from django.contrib.postgres.fields import CICharField
+from django.db import models
 
 __all__ = ["State"]
 

--- a/src/django/api/models/submission.py
+++ b/src/django/api/models/submission.py
@@ -1,11 +1,11 @@
-from django.db import models
-from django.core.exceptions import ValidationError
 from django.contrib.gis.db import models as gis_models
-from django.utils.functional import cached_property
+from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 from .boundary import Boundary
-from .user import User, Roles
+from .user import Roles, User
 
 __all__ = ["Submission", "Approval", "Review", "Annotation"]
 

--- a/src/django/api/models/user.py
+++ b/src/django/api/models/user.py
@@ -1,4 +1,3 @@
-from django.db import models
 from django.contrib.auth.models import (
     AbstractBaseUser,
     BaseUserManager,
@@ -6,10 +5,11 @@ from django.contrib.auth.models import (
 )
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator
+from django.db import models
 from django.utils import timezone
 
-from .utility import Utility
 from .state import State
+from .utility import Utility
 
 __all__ = ["EmailAsUsernameUserManager", "User"]
 

--- a/src/django/api/models/utility.py
+++ b/src/django/api/models/utility.py
@@ -1,6 +1,7 @@
-from django.db import models
 from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.geos import Point
+from django.db import models
+
 from .state import State
 
 RALEIGH = Point(-78.6382, 35.7796)

--- a/src/django/api/parsers.py
+++ b/src/django/api/parsers.py
@@ -1,4 +1,5 @@
 import json
+
 from rest_framework.parsers import MultiPartParser
 
 

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -1,4 +1,4 @@
-from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
 from .models.user import Roles
 

--- a/src/django/api/serializers/__init__.py
+++ b/src/django/api/serializers/__init__.py
@@ -1,11 +1,11 @@
 # flake8: noqa: F401
-from .user import UserSerializer
-from .utility import UtilitySerializer
-from .state import StateIDSerializer
 from .boundary import (
-    BoundaryListSerializer,
     BoundaryDetailSerializer,
+    BoundaryListSerializer,
     NewBoundarySerializer,
 )
-from .shape import ShapeSerializer, ShapeUpdateSerializer
 from .reference_image import ReferenceImageSerializer
+from .shape import ShapeSerializer, ShapeUpdateSerializer
+from .state import StateIDSerializer
+from .user import UserSerializer
+from .utility import UtilitySerializer

--- a/src/django/api/serializers/activity_log.py
+++ b/src/django/api/serializers/activity_log.py
@@ -1,12 +1,8 @@
-from rest_framework.serializers import (
-    ModelSerializer,
-    CharField,
-    DateTimeField,
-)
+from rest_framework.serializers import CharField, DateTimeField, ModelSerializer
 
 from ..models import Submission
 from ..models.boundary import BOUNDARY_STATUS
-from ..models.submission import Review, Approval
+from ..models.submission import Approval, Review
 
 
 class EventSerializer(ModelSerializer):

--- a/src/django/api/serializers/annotation.py
+++ b/src/django/api/serializers/annotation.py
@@ -1,5 +1,5 @@
+from rest_framework.fields import BooleanField, CharField
 from rest_framework.serializers import ModelSerializer, Serializer
-from rest_framework.fields import CharField, BooleanField
 
 from ..models.submission import Annotation
 

--- a/src/django/api/serializers/auth.py
+++ b/src/django/api/serializers/auth.py
@@ -1,5 +1,5 @@
-from django.db import transaction
 from dj_rest_auth.serializers import PasswordResetConfirmSerializer
+from django.db import transaction
 
 
 class UserChosenPasswordResetConfirmSerializer(PasswordResetConfirmSerializer):

--- a/src/django/api/serializers/boundary.py
+++ b/src/django/api/serializers/boundary.py
@@ -1,33 +1,31 @@
 from operator import itemgetter
 
 from django.db import transaction
-
 from rest_framework.serializers import (
-    ModelSerializer,
     CharField,
     ChoiceField,
     DateTimeField,
     FileField,
-    SerializerMethodField,
+    ModelSerializer,
     PrimaryKeyRelatedField,
+    SerializerMethodField,
 )
 
-from ..models.boundary import Boundary, BOUNDARY_STATUS
-from ..models.utility import Utility
-from ..models.submission import Submission, Review, Annotation
-from ..models.user import User
-from ..models.reference_image import ReferenceImage
-
-from .reference_image import ReferenceImageSerializer
 from ..fields import ShapefileField
+from ..models.boundary import BOUNDARY_STATUS, Boundary
+from ..models.reference_image import ReferenceImage
+from ..models.submission import Annotation, Review, Submission
+from ..models.user import User
+from ..models.utility import Utility
 from .activity_log import (
-    ActivityDraftedSerializer,
-    ActivitySubmittedSerializer,
-    ActivityReviewStartedSerializer,
-    ActivityReviewedSerializer,
     ActivityApprovedSerializer,
+    ActivityDraftedSerializer,
+    ActivityReviewedSerializer,
+    ActivityReviewStartedSerializer,
+    ActivitySubmittedSerializer,
     ActivityUnapprovedSerializer,
 )
+from .reference_image import ReferenceImageSerializer
 
 
 class StatusField(ChoiceField):

--- a/src/django/api/serializers/shape.py
+++ b/src/django/api/serializers/shape.py
@@ -1,6 +1,6 @@
-from rest_framework.serializers import Serializer
-from rest_framework.fields import ListField, FileField, FloatField
 from django.contrib.gis.geos import Polygon
+from rest_framework.fields import FileField, FloatField, ListField
+from rest_framework.serializers import Serializer
 
 from api.fields import ShapefileField
 

--- a/src/django/api/tests/base.py
+++ b/src/django/api/tests/base.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from django.utils import timezone
-
 from rest_framework.test import APIClient
 
 from api.models import (
@@ -11,15 +10,15 @@ from api.models import (
     Roles,
     State,
     Submission,
-    Utility,
     User,
+    Utility,
 )
 
 from .data.shapes import (
+    POINT_IN_RALEIGH_FAKE_TRIANGLE,
     RALEIGH_FAKE_RECTANGLE,
     RALEIGH_FAKE_TRIANGLE,
     RALEIGH_FAKE_ZIGZAG,
-    POINT_IN_RALEIGH_FAKE_TRIANGLE,
 )
 
 

--- a/src/django/api/tests/boundary.py
+++ b/src/django/api/tests/boundary.py
@@ -1,7 +1,6 @@
 import json
 
 from django.urls import reverse
-
 from rest_framework import status
 
 from api.models import Submission, Utility

--- a/src/django/api/tests/reference_image.py
+++ b/src/django/api/tests/reference_image.py
@@ -1,6 +1,5 @@
 from django.urls import reverse
 from django.utils.log import request_logger
-
 from rest_framework import status
 
 from api.models import ReferenceImage

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -2,18 +2,18 @@ from django.urls import include, path
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import Login, Logout
+from .views.annotations import AnnotationCreateView, AnnotationUpdateView
 from .views.boundary import (
+    BoundaryApproveView,
     BoundaryDetailView,
+    BoundaryDraftView,
     BoundaryListView,
     BoundaryShapeView,
     BoundarySubmitView,
-    BoundaryDraftView,
-    BoundaryApproveView,
     BoundaryUnapproveView,
 )
-from .views.reference_image import ReferenceImageList, ReferenceImageDetail
+from .views.reference_image import ReferenceImageDetail, ReferenceImageList
 from .views.review import ReviewCreateView, ReviewFinishView
-from .views.annotations import AnnotationCreateView, AnnotationUpdateView
 
 urlpatterns = [
     path("auth/login/", Login.as_view()),

--- a/src/django/api/views/annotations.py
+++ b/src/django/api/views/annotations.py
@@ -1,16 +1,15 @@
 from django.shortcuts import get_object_or_404
-
-from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.status import HTTP_201_CREATED, HTTP_204_NO_CONTENT
+from rest_framework.views import APIView
 
-from ..permissions import UserCanReviewBoundaries
-from .boundary import get_boundary_queryset_for_user
-from ..models.boundary import BOUNDARY_STATUS
 from ..exceptions import BadRequestException
-from ..serializers.annotation import NewAnnotationSerializer, UpdateAnnotationSerializer
+from ..models.boundary import BOUNDARY_STATUS
 from ..models.submission import Annotation
+from ..permissions import UserCanReviewBoundaries
+from ..serializers.annotation import NewAnnotationSerializer, UpdateAnnotationSerializer
+from .boundary import get_boundary_queryset_for_user
 
 
 class AnnotationAPIView(APIView):

--- a/src/django/api/views/auth.py
+++ b/src/django/api/views/auth.py
@@ -1,13 +1,12 @@
-from rest_framework import status
-from rest_framework.permissions import AllowAny
-from rest_framework.response import Response
-from rest_framework.exceptions import AuthenticationFailed
 from dj_rest_auth.views import LoginView, LogoutView
-
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
+from rest_framework import status
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
 from ..serializers import UserSerializer
 

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -3,25 +3,24 @@ import json
 from django.db.models import Prefetch, functions
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
-
-from rest_framework.response import Response
-from rest_framework.views import APIView
-from rest_framework.permissions import IsAuthenticated
-from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.exceptions import NotAuthenticated
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.views import APIView
 
-from ..serializers import (
-    BoundaryListSerializer,
-    BoundaryDetailSerializer,
-    ShapeUpdateSerializer,
-    NewBoundarySerializer,
-)
-from ..parsers import NewBoundaryParser
-from ..models import Roles, Submission, ReferenceImage
+from ..exceptions import BadRequestException
+from ..models import ReferenceImage, Roles, Submission
 from ..models.boundary import BOUNDARY_STATUS, Boundary
 from ..models.submission import Approval
-from ..exceptions import BadRequestException
-from ..permissions import UserCanWriteBoundaries, UserCanUnapproveBoundaries
+from ..parsers import NewBoundaryParser
+from ..permissions import UserCanUnapproveBoundaries, UserCanWriteBoundaries
+from ..serializers import (
+    BoundaryDetailSerializer,
+    BoundaryListSerializer,
+    NewBoundarySerializer,
+    ShapeUpdateSerializer,
+)
 
 
 def get_boundary_queryset_for_user(user):

--- a/src/django/api/views/reference_image.py
+++ b/src/django/api/views/reference_image.py
@@ -1,5 +1,4 @@
 from django.shortcuts import get_object_or_404
-
 from rest_framework import generics
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated

--- a/src/django/api/views/review.py
+++ b/src/django/api/views/review.py
@@ -1,15 +1,14 @@
 from django.shortcuts import get_object_or_404
-
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.views import APIView
-from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.response import Response
+from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.views import APIView
 
-from .boundary import get_boundary_queryset_for_user
 from ..exceptions import BadRequestException
-from ..models.submission import Review
 from ..models.boundary import BOUNDARY_STATUS
+from ..models.submission import Review
 from ..permissions import UserCanReviewBoundaries
+from .boundary import get_boundary_queryset_for_user
 
 
 class ReviewView(APIView):

--- a/src/django/format.sh
+++ b/src/django/format.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Run isort --check-only before fixing to ensure a failure code is emitted
+if ! isort ${*:1} --check-only; then
+    isort ${*:1}
+fi
+
+# Run black with --check before fixing to ensure a failure code is emitted
+if ! black \
+    --skip-string-normalization \
+    --extend-exclude migrations ${*:1} \
+    --quiet --check; then
+        black \
+            --skip-string-normalization \
+            --extend-exclude migrations \
+            --quiet ${*:1}
+fi

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -11,9 +11,9 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 
 import os
-import requests
-
 from pathlib import Path
+
+import requests
 from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.

--- a/src/django/iow/urls.py
+++ b/src/django/iow/urls.py
@@ -13,9 +13,9 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, include
 from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, path
 
 from . import settings
 

--- a/src/django/requirements.txt
+++ b/src/django/requirements.txt
@@ -16,6 +16,7 @@ filetype==1.0.13
 fiona==1.8.22
 flake8==4.0.1
 gunicorn==20.1.0
+isort==5.10.1
 psycopg2==2.9.3
 pycodestyle==2.8.0
 pyflakes==2.4.0

--- a/src/django/setup.cfg
+++ b/src/django/setup.cfg
@@ -1,2 +1,6 @@
 [flake8]
 max-line-length = 88
+
+[isort]
+skip=api/migrations
+profile=black


### PR DESCRIPTION
## Overview
- Create a format script that has black and isort auto format python files
- Provide a pre-commit hook to run the format script

### Demo
Updated demo:

https://user-images.githubusercontent.com/38668450/200062598-d9021a81-c6fc-4445-b3a6-880d80139680.mp4


### Notes
- ~`pre-commit` could be specified in a `requirements-dev.txt`, and the README edited to just suggest installing _that_, but I figured with just one package, to suggest installing it directly.~ Got this in `scripts/bootstrap` now.

## Testing Instructions

- `scripts/bootstrap`
- Make changes to js and python that will cause lint failures, or edit a Django model to necessitate a migration
- Attempt to commit
  - [ ] verify you are prevented from committing


## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
