### PR TITLE
Add support for approving/unapprove boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unapproving to data model [#178](https://github.com/azavea/iow-boundary-tool/pull/178)
 - Add ability to submit reviews [#181](https://github.com/azavea/iow-boundary-tool/pull/181)
 - Add ability to resubmit boundaries [#185](https://github.com/azavea/iow-boundary-tool/pull/185)
+- Add support for approving/unapproving boundaries [#186](https://github.com/azavea/iow-boundary-tool/pull/186)
 
 ### Changed
 

--- a/doc/arch/adr-002-rest-api.md
+++ b/doc/arch/adr-002-rest-api.md
@@ -33,8 +33,8 @@ Also present are `/auth/password/reset/` and `/auth/password/reset/confirm/` end
 | `/boundaries/{id}/review/annotations/{id}/` | PUT    | `{ annotation }` | Validator      | 200 OK,<br />404 Not Found                                 | Updates an annotation in the latest review. Older reviews are read-only, so no need to specify review id.          |
 | `/boundaries/{id}/review/annotations/{id}/` | DELETE | -                | Validator      | 204 NO Content,<br />404 Not Found                         | Deletes an annotation in the latest review. Older reviews are read-only, so no need to specify review id.          |
 | `/boundaries/{id}/draft/`                   | POST   | -                | Contributor    | 204 No Content,<br />404 Not Found                         | Creates a new draft submission for a boundary after a review                                                       |
-| `/boundaries/{id}/approve/`                 | POST   | -                | Validator      | 200 OK,<br />404 Not Found                                 | Approves a boundary                                                                                                |
-| `/boundaries/{id}/unapprove/`               | POST   | -                | Validator      | 200 OK,<br />404 Not Found                                 | Unapproves a boundary                                                                                              |
+| `/boundaries/{id}/approve/`                 | POST   | -                | Validator      | 204 No Content,<br />404 Not Found                         | Approves a boundary                                                                                                |
+| `/boundaries/{id}/unapprove/`               | POST   | -                | Validator      | 204 No Content,<br />404 Not Found                         | Unapproves a boundary                                                                                              |
 
 ### User
 

--- a/src/app/src/api/boundaries.js
+++ b/src/app/src/api/boundaries.js
@@ -167,6 +167,22 @@ const boundaryApi = api.injectEndpoints({
             }),
             invalidatesTags: getUpdateItemTagInvalidator(TAGS.BOUNDARY),
         }),
+
+        approveBoundary: build.mutation({
+            query: boundaryId => ({
+                url: `/boundaries/${boundaryId}/approve/`,
+                method: 'POST',
+            }),
+            invalidatesTags: getUpdateItemTagInvalidator(TAGS.BOUNDARY),
+        }),
+
+        unapproveBoundary: build.mutation({
+            query: boundaryId => ({
+                url: `/boundaries/${boundaryId}/unapprove/`,
+                method: 'POST',
+            }),
+            invalidatesTags: getUpdateItemTagInvalidator(TAGS.BOUNDARY),
+        }),
     }),
 });
 
@@ -179,4 +195,6 @@ export const {
     useDeleteBoundaryShapeMutation,
     useSubmitBoundaryMutation,
     useCreateDraftMutation,
+    useApproveBoundaryMutation,
+    useUnapproveBoundaryMutation,
 } = boundaryApi;

--- a/src/app/src/components/Submissions/Detail/Detail.js
+++ b/src/app/src/components/Submissions/Detail/Detail.js
@@ -10,7 +10,11 @@ import {
 } from '@chakra-ui/react';
 import { ArrowLeftIcon } from '@heroicons/react/outline';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useGetBoundaryDetailsQuery } from '../../../api/boundaries';
+import {
+    useApproveBoundaryMutation,
+    useGetBoundaryDetailsQuery,
+    useUnapproveBoundaryMutation,
+} from '../../../api/boundaries';
 import CenteredSpinner from '../../CenteredSpinner';
 import { CheckCircleIcon } from '@heroicons/react/outline';
 
@@ -51,6 +55,16 @@ export default function SubmissionDetail() {
         { isLoading: isCreatingDraft, error: createDraftMutationError },
     ] = useCreateDraftMutation();
 
+    const [
+        approveBoundary,
+        { isLoading: isApprovingBoundary, error: approveBoundaryError },
+    ] = useApproveBoundaryMutation();
+
+    const [
+        unapproveBoundary,
+        { isLoading: isUnpprovingBoundary, error: unapproveBoundaryError },
+    ] = useUnapproveBoundaryMutation();
+
     useEndpointToastError(
         startReviewError,
         'There was an error starting a review.'
@@ -61,7 +75,23 @@ export default function SubmissionDetail() {
         'There was an error creating a new submission.'
     );
 
-    if (isFetching || isStartingReview || isCreatingDraft) {
+    useEndpointToastError(
+        approveBoundaryError,
+        'There was an error approving the submission.'
+    );
+
+    useEndpointToastError(
+        unapproveBoundaryError,
+        'There was an error unapproving the submission'
+    );
+
+    if (
+        isFetching ||
+        isStartingReview ||
+        isCreatingDraft ||
+        isApprovingBoundary ||
+        isUnpprovingBoundary
+    ) {
         return <CenteredSpinner />;
     }
 
@@ -69,7 +99,10 @@ export default function SubmissionDetail() {
         return null;
     }
 
-    const { canApprove } = getBoundaryPermissions({ boundary, user });
+    const { canApprove, canUnapprove } = getBoundaryPermissions({
+        boundary,
+        user,
+    });
 
     return (
         <VStack
@@ -104,8 +137,19 @@ export default function SubmissionDetail() {
                             mb={4}
                             alignSelf='flex-end'
                             rightIcon={heroToChakraIcon(CheckCircleIcon)()}
+                            onClick={() => approveBoundary(boundary.id)}
                         >
                             Mark approved
+                        </Button>
+                    )}
+                    {canUnapprove && (
+                        <Button
+                            mb={4}
+                            alignSelf='flex-end'
+                            rightIcon={heroToChakraIcon(CheckCircleIcon)()}
+                            onClick={() => unapproveBoundary(boundary.id)}
+                        >
+                            Mark unapproved
                         </Button>
                     )}
 

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -152,7 +152,7 @@ export function getBoundaryPermissions({ boundary, user }) {
         Object.entries(getBoundaryPermissionForRole(role)).map(
             ([permissionType, validStatuses]) => [
                 permissionType,
-                validStatuses?.includes(status) ?? false,
+                validStatuses.includes(status),
             ]
         )
     );

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -176,7 +176,10 @@ function getBoundaryPermissionForRole(role) {
                     BOUNDARY_STATUS.SUBMITTED,
                     BOUNDARY_STATUS.IN_REVIEW,
                 ],
-                canApprove: [BOUNDARY_STATUS.SUBMITTED],
+                canApprove: [
+                    BOUNDARY_STATUS.SUBMITTED,
+                    BOUNDARY_STATUS.IN_REVIEW,
+                ],
                 canUnapprove: [BOUNDARY_STATUS.APPROVED],
             };
 

--- a/src/django/api/models/submission.py
+++ b/src/django/api/models/submission.py
@@ -121,6 +121,10 @@ class Approval(models.Model):
     def revoked(self):
         return self.unapproved_at is not None
 
+    def unapprove(self, unapproved_by):
+        self.unapproved_at = datetime.now(tz=timezone.utc)
+        self.unapproved_by = unapproved_by
+
 
 class Annotation(models.Model):
     review = models.ForeignKey(

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -25,3 +25,13 @@ class UserCanWriteBoundaries(BasePermission):
             request.user.role == Roles.CONTRIBUTOR
             or request.user.role == Roles.ADMINISTRATOR
         )
+
+
+class UserCanUnapproveBoundaries(BasePermission):
+    message = 'You are not able to unapprove boundaries.'
+
+    def has_permission(self, request, view):
+        return request_is_read_only(request) or (
+            request.user.role == Roles.VALIDATOR
+            or request.user.role == Roles.ADMINISTRATOR
+        )

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -8,6 +8,8 @@ from .views.boundary import (
     BoundaryShapeView,
     BoundarySubmitView,
     BoundaryDraftView,
+    BoundaryApproveView,
+    BoundaryUnapproveView,
 )
 from .views.reference_image import ReferenceImageList, ReferenceImageDetail
 from .views.review import ReviewCreateView, ReviewFinishView
@@ -55,6 +57,16 @@ urlpatterns = [
         "boundaries/<int:boundary_id>/draft/",
         BoundaryDraftView.as_view(),
         name='start_draft',
+    ),
+    path(
+        "boundaries/<int:boundary_id>/approve/",
+        BoundaryApproveView.as_view(),
+        name='approve_boundary',
+    ),
+    path(
+        "boundaries/<int:boundary_id>/unapprove/",
+        BoundaryUnapproveView.as_view(),
+        name='unapprove_boundary',
     ),
 ]
 

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -275,9 +275,12 @@ class BoundaryApproveView(BoundaryView):
                 )
 
         elif user_role == Roles.VALIDATOR:
-            if boundary.status != BOUNDARY_STATUS.SUBMITTED:
+            if boundary.status not in [
+                BOUNDARY_STATUS.SUBMITTED,
+                BOUNDARY_STATUS.IN_REVIEW,
+            ]:
                 raise BadRequestException(
-                    'This boundary must be submitted to be approved.',
+                    'This boundary must be submitted or in review to be approved.',
                 )
 
         else:


### PR DESCRIPTION
## Overview

This PR adds the ability to approve and unapprove boundaries

Closes #151 

## Testing Instructions

- Login as v1@azavea.com
  - [x] Ensure "Mark approved" button appears on "Submitted" submissions and approves the submission
  - [x] Ensure "Approved" submissions can be unapproved with the "Mark unapproved" button
  - [x] Ensure all other status boundaries don't have an approval button
- Login as a1@azavea.com
  - [x] Ensuree "Mark approved" button appears on "Submitted", "In Review", and "Needs Revision" submissions and approves the submission
  - [x] Ensure "Approved" submissions can be unapproved with the "Mark unapproved" button
  - [x] Ensure all other status ("Draft") boundaries don't have an approval button

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
