### PR TITLE
Fix Submit Boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix add polygon [#169](https://github.com/azavea/iow-boundary-tool/pull/169)
 - Fix user authentication [#170](https://github.com/azavea/iow-boundary-tool/pull/170)
 - Fix view submission details link destination [#174](https://github.com/azavea/iow-boundary-tool/pull/174)
+- Fix submit boundary [#195](https://github.com/azavea/iow-boundary-tool/pull/195)
 
 ### Deprecated
 

--- a/src/app/src/components/DrawTools/DrawTools.js
+++ b/src/app/src/components/DrawTools/DrawTools.js
@@ -28,6 +28,8 @@ export default function DrawTools() {
     const { status } = useDrawBoundary();
     const { canWrite, canReview } = useDrawPermissions();
 
+    const afterSubmitDialogController = useDialogController(false);
+
     const draftMode = status === BOUNDARY_STATUS.DRAFT && canWrite;
     const reviewMode = status === BOUNDARY_STATUS.IN_REVIEW && canReview;
 
@@ -36,17 +38,26 @@ export default function DrawTools() {
             <EditToolbar />
             <MapControlButtons />
 
-            {draftMode && <DraftTools />}
+            {draftMode && (
+                <DraftTools onSuccess={afterSubmitDialogController.open} />
+            )}
+
             {reviewMode && <ReviewTools />}
+
+            {status === BOUNDARY_STATUS.SUBMITTED && (
+                <AfterSubmitModal
+                    isOpen={afterSubmitDialogController.isOpen}
+                    onClose={afterSubmitDialogController.close}
+                />
+            )}
 
             <AnnotationMarkers />
         </>
     );
 }
 
-function DraftTools() {
+function DraftTools({ onSuccess }) {
     const submitDialogController = useDialogController(false);
-    const afterSubmitDialogController = useDialogController(false);
 
     return (
         <>
@@ -55,11 +66,7 @@ function DraftTools() {
             <SubmitModal
                 isOpen={submitDialogController.isOpen}
                 onClose={submitDialogController.close}
-                onSuccess={afterSubmitDialogController.open}
-            />
-            <AfterSubmitModal
-                isOpen={afterSubmitDialogController.isOpen}
-                onClose={afterSubmitDialogController.close}
+                onSuccess={onSuccess}
             />
 
             <ReviewAndSaveButton

--- a/src/django/api/models/submission.py
+++ b/src/django/api/models/submission.py
@@ -1,9 +1,8 @@
-from datetime import datetime, timezone
-
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.contrib.gis.db import models as gis_models
 from django.utils.functional import cached_property
+from django.utils import timezone
 
 from .boundary import Boundary
 from .user import User, Roles
@@ -84,7 +83,7 @@ class Review(models.Model):
         super().clean()
 
     def finish(self, reviewed_by):
-        self.reviewed_at = datetime.now(tz=timezone.utc)
+        self.reviewed_at = timezone.now()
         self.reviewed_by = reviewed_by
 
 
@@ -122,7 +121,7 @@ class Approval(models.Model):
         return self.unapproved_at is not None
 
     def unapprove(self, unapproved_by):
-        self.unapproved_at = datetime.now(tz=timezone.utc)
+        self.unapproved_at = timezone.now()
         self.unapproved_by = unapproved_by
 
 
@@ -143,4 +142,4 @@ class Annotation(models.Model):
         return self.resolved_at is not None
 
     def resolve(self):
-        self.resolved_at = datetime.now(tz=timezone.utc)
+        self.resolved_at = timezone.now()

--- a/src/django/api/tests/base.py
+++ b/src/django/api/tests/base.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timezone
-
 from django.test import TestCase
+from django.utils import timezone
 
 from rest_framework.test import APIClient
 
@@ -147,31 +146,31 @@ class BoundarySyncAPITestCase(TestCase):
 
         # submitted
         Submission.objects.filter(pk=submission_2.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
 
         Submission.objects.filter(pk=submission_3.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
 
         Submission.objects.filter(pk=submission_4.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
 
         Submission.objects.filter(pk=submission_5.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
 
         Submission.objects.filter(pk=submission_6.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
@@ -181,53 +180,53 @@ class BoundarySyncAPITestCase(TestCase):
             submission=submission_3,
             reviewed_by=cls.validator,
             notes="Notes for the review.",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         review_submission_4 = Review.objects.create(
             submission=submission_4,
             reviewed_by=cls.validator,
             notes="Notes for the review.",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         review_submission_6 = Review.objects.create(
             submission=submission_6,
             reviewed_by=cls.validator,
             notes="Notes for the review.",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         Annotation.objects.create(
             review=review_submission_3,
             location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
             comment="Comment on review",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         Annotation.objects.create(
             review=review_submission_4,
             location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
             comment="Comment on review",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         Annotation.objects.create(
             review=review_submission_6,
             location=POINT_IN_RALEIGH_FAKE_TRIANGLE,
             comment="Comment on review",
-            created_at=datetime.now(tz=timezone.utc),
+            created_at=timezone.now(),
         )
 
         # needs revision
         Review.objects.filter(pk=review_submission_4.pk).update(
-            reviewed_at=datetime.now(tz=timezone.utc),
+            reviewed_at=timezone.now(),
             reviewed_by=cls.validator,
             notes="Final notes for the review.",
         )
 
         Review.objects.filter(pk=review_submission_6.pk).update(
-            reviewed_at=datetime.now(tz=timezone.utc),
+            reviewed_at=timezone.now(),
             reviewed_by=cls.validator,
             notes="Final notes for the review.",
         )
@@ -243,7 +242,7 @@ class BoundarySyncAPITestCase(TestCase):
         # re-submit for review
 
         Submission.objects.filter(pk=resubmission_6.pk).update(
-            submitted_at=datetime.now(tz=timezone.utc),
+            submitted_at=timezone.now(),
             submitted_by=cls.contributor,
             notes="Notes for the test submission.",
         )
@@ -251,17 +250,17 @@ class BoundarySyncAPITestCase(TestCase):
         # approved
         approval_6 = Approval.objects.create(
             submission=resubmission_6,
-            approved_at=datetime.now(tz=timezone.utc),
+            approved_at=timezone.now(),
             approved_by=cls.validator,
         )
 
         approval_6.unapproved_by = cls.validator
-        approval_6.unapproved_at = datetime.now(tz=timezone.utc)
+        approval_6.unapproved_at = timezone.now()
         approval_6.save()
 
         Approval.objects.create(
             submission=submission_5,
-            approved_at=datetime.now(tz=timezone.utc),
+            approved_at=timezone.now(),
             approved_by=cls.validator,
         )
 

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -1,10 +1,8 @@
 import json
 
-from datetime import datetime, timezone
-
-from django.conf import settings
 from django.db.models import Prefetch, functions
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -146,7 +144,7 @@ class BoundarySubmitView(APIView):
                 "Cannot submit boundary with status: {}".format(boundary.status.value),
             )
 
-        now = datetime.now(tz=timezone(settings.TIME_ZONE))
+        now = timezone.now()
         yyyy_mm_dd = now.isoformat()[:10]
         fp = f"{boundary.utility.pwsid}_{boundary.utility.address_city}_{yyyy_mm_dd}"
 


### PR DESCRIPTION
## Overview

There are two issues with the Submit Boundary feature:
1. API request to submit is broken. This is due to invalid timezone strings.
2. The "After Submit" modal isn't showing up. This is because it was moved to the draft tools which don't render when a submission is in "Submitted" state.

To Solve:
1. Use django's `timezone.now()`. See https://docs.djangoproject.com/en/3.2/topics/i18n/timezones/#naive-and-aware-datetime-objects. The seemed like a good idea to do everywhere so it's been replaced everywhere.
2. Move the "After Submit" modal to the parent, DrawTools component and render it only when in "Submitted" state. Still tie into the submit `onSuccess` so it doesn't show up on subsequent visits to the page.

Closes #193  

## Testing Instructions

- `./scripts/resetdb`
- Log in as contributor
- Go to a "Draft" or a submission that "Needs Revisions"
- Make changes and submit
  - [x] Ensure "After Submit" dialog shows up
- Revisit submission page
  - [x] Ensure "After Submit" dialog is not visible
  - [x] Ensure submission was saved successfully

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
