### PR TITLE
Fix contributor welcome redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix user authentication [#170](https://github.com/azavea/iow-boundary-tool/pull/170)
 - Fix view submission details link destination [#174](https://github.com/azavea/iow-boundary-tool/pull/174)
 - Fix submit boundary [#195](https://github.com/azavea/iow-boundary-tool/pull/195)
+- Fix contributor welcome redirect [#197](https://github.com/azavea/iow-boundary-tool/pull/197)
 
 ### Deprecated
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -71,7 +71,16 @@ function PrivateRoutes() {
                 <Route path='/submissions/*' element={<Submissions />} />
                 <Route
                     path='*'
-                    element={<Navigate to={'/submissions'} replace />}
+                    element={
+                        <Navigate
+                            to={
+                                hasWelcomePageAccess
+                                    ? '/welcome'
+                                    : '/submissions'
+                            }
+                            replace
+                        />
+                    }
                 />
             </Routes>
         </>

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -56,10 +56,9 @@ function PrivateRoutes() {
     return (
         <>
             <Routes>
-                {hasWelcomePageAccess && (
-                    <Route path='/welcome' element={<Outlet />} />
-                )}
-                <Route path='*' element={<NavBar />} />
+                <Route path='/draw/*' element={<NavBar />} />
+                <Route path='/submissions/*' element={<NavBar />} />
+                <Route path='*' element={<Outlet />} />
             </Routes>
 
             <Routes>


### PR DESCRIPTION
## Overview

This PR updates the login redirect for contributors so they are taken to the welcome page if they select a utility that has no submissions.

It also updates the navbar to render on only on explicitly listed pages. This keeps it from flashing when the contributor is redirected to /welcome.

Closes #190 

### Notes

Having `/draw` in `/submissions` like `/submissions/4/draw` would simplify how the navbar is included and would help with solving #184.

## Testing Instructions

- Logout
- http://localhost:4545/
- Log in as c1@azavea.com
- Select other utility
  - [x] Ensure you are redirected to the welcome page

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
