### PR TITLE
Add S3 Permissions to ECS Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add format script and pre-commit hook [#179](https://github.com/azavea/iow-boundary-tool/pull/179)
 - Add ability to resubmit boundaries [#185](https://github.com/azavea/iow-boundary-tool/pull/185)
 - Add support for approving/unapproving boundaries [#186](https://github.com/azavea/iow-boundary-tool/pull/186)
+- Add S3 Permissions to ECS Tasks [#199](https://github.com/azavea/iow-boundary-tool/pull/199)
 
 ### Changed
 

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -53,3 +53,26 @@ resource "aws_iam_role_policy" "scoped_email_sending" {
   role   = aws_iam_role.ecs_task_role.name
   policy = data.aws_iam_policy_document.scoped_email_sending.json
 }
+
+data "aws_iam_policy_document" "s3_read_write_data_bucket" {
+    statement {
+        effect = "Allow"
+
+        resources = [
+            aws_s3_bucket.data.arn,
+            "${aws_s3_bucket.data.arn}/*",
+        ]
+
+        actions = [
+            "s3:GetObject",
+            "s3:ListBucket",
+            "s3:PutObject",
+        ]
+    }
+}
+
+resource "aws_iam_role_policy" "s3_read_write_data_bucket" {
+    name   = "S3ReadWriteData"
+    role   = aws_iam_role.ecs_task_role.name
+    policy = data.aws_iam_policy_document.s3_read_write_data_bucket.json
+}


### PR DESCRIPTION
## Overview

Without these, we cannot upload files on staging or production.

Closes #194

### Demo

https://user-images.githubusercontent.com/1430060/201412566-0d6c886c-53f4-465e-8105-5ccd2405b8b9.mp4

## Testing Instructions

- If nothing else has been deployed to staging, go to https://staging.iow.azavea.com
- Login as a Contributor
- Go to an existing boundary and upload a new shape
- Upload a new reference image
  - [x] Ensure they are successful

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
