### PR TITLE
Validator update emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add ability to resubmit boundaries [#185](https://github.com/azavea/iow-boundary-tool/pull/185)
 - Add support for approving/unapproving boundaries [#186](https://github.com/azavea/iow-boundary-tool/pull/186)
 - Add S3 Permissions to ECS Tasks [#199](https://github.com/azavea/iow-boundary-tool/pull/199)
+- Add submit boundary validator email [#201](https://github.com/azavea/iow-boundary-tool/pull/201)
 
 ### Changed
 

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -1,0 +1,54 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import send_mail
+from django.template.loader import get_template
+
+from .models.user import Roles
+
+logger = logging.getLogger(__name__)
+
+
+def send_boundary_submitted_validator_email(request, updated_boundary):
+    subj_template = get_template('mail/boundary_submitted_validator_subject.txt')
+    body_template = get_template('mail/boundary_submitted_validator_body.txt')
+
+    validators = updated_boundary.utility.state.users.filter(role=Roles.VALIDATOR)
+    validator_emails = [user.email for user in validators.only('email')]
+
+    template_data = {
+        "city": updated_boundary.utility.address_city,
+        "pwsid": updated_boundary.utility.pwsid,
+        "details_link": "{}/submissions/{}/".format(
+            make_iow_url(request),
+            updated_boundary.id,
+        ),
+    }
+
+    subject = subj_template.render(template_data)
+    body = body_template.render(template_data)
+
+    for email in validator_emails:
+        try:
+            send_mail(
+                subject,
+                body,
+                from_email=None,
+                recipient_list=[email],
+            )
+        except Exception as exception:
+            logger.error(
+                'Could not send validator update email to %s. Caught exception:\n%s',
+                (email, exception),
+            )
+
+
+def make_iow_url(request):
+    if settings.ENVIRONMENT == 'Development':
+        protocol = 'http'
+        host = 'localhost:4545'
+    else:
+        protocol = 'https'
+        host = request.get_host()
+
+    return f'{protocol}://{host}'

--- a/src/django/api/templates/mail/boundary_submitted_validator_body.txt
+++ b/src/django/api/templates/mail/boundary_submitted_validator_body.txt
@@ -1,0 +1,6 @@
+Submission for review - {{city}} {{pwsid}}
+
+A new boundary has been submitted for review.
+
+Review submission:
+{{ details_link }}

--- a/src/django/api/templates/mail/boundary_submitted_validator_subject.txt
+++ b/src/django/api/templates/mail/boundary_submitted_validator_subject.txt
@@ -1,0 +1,1 @@
+Submission for review - {{city}} {{pwsid}}

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -137,7 +137,7 @@ class BoundarySubmitView(APIView):
 
     def patch(self, request, id, format=None):
         boundary_set = get_boundary_queryset_for_user(request.user)
-        boundary_set = boundary_set.prefetch_related("submissions")
+        boundary_set = boundary_set.select_related('utility__state')
         boundary = get_object_or_404(boundary_set, pk=id)
         if boundary.status != BOUNDARY_STATUS.DRAFT:
             raise BadRequestException(

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -10,6 +10,7 @@ from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.views import APIView
 
 from ..exceptions import BadRequestException
+from ..mail import send_boundary_submitted_validator_email
 from ..models import ReferenceImage, Roles, Submission
 from ..models.boundary import BOUNDARY_STATUS, Boundary
 from ..models.submission import Approval
@@ -155,6 +156,8 @@ class BoundarySubmitView(APIView):
         boundary.latest_submission.submitted_by = request.user
         boundary.latest_submission.submitted_at = now
         boundary.latest_submission.save()
+
+        send_boundary_submitted_validator_email(request, boundary)
 
         return Response(status=HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Overview

This PR adds email updates that get sent to validators when a boundary shape is submitted.

Closes #162 

### Demo

<img width="375" alt="Screenshot 2022-11-11 at 2 37 22 PM" src="https://user-images.githubusercontent.com/8356789/201431085-d79017f5-8f7f-441b-b1ba-abb8bf97ac28.png">

## Testing Instructions

- Login as c1@azavea.com
- Submit a Review
- Check server console for email message

Also, the staging server might still be on this branch from when I pushed the latest changes. So these steps might work as well:

- Add and verify email with AWS SES
- https://staging.iow.azavea.com/
- Login as a1@azavea.com
- Change v1@azavea.com to your email address
- Submit a boundary
- Check email
- Change email back to v1@azavea.com

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
