### PR TITLE
Update Download, Replace Polygon Workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for approving/unapproving boundaries [#186](https://github.com/azavea/iow-boundary-tool/pull/186)
 - Add S3 Permissions to ECS Tasks [#199](https://github.com/azavea/iow-boundary-tool/pull/199)
 - Add submit boundary validator email [#201](https://github.com/azavea/iow-boundary-tool/pull/201)
+- Add Yellow color for In Review submissions [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
 
 ### Changed
 
@@ -81,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guard Draw Page Actions [#156](https://github.com/azavea/iow-boundary-tool/pull/156)
 - Only redirect to /welcome for new boundaries [#175](https://github.com/azavea/iow-boundary-tool/pull/175)
 - Update File Upload UI [#198](https://github.com/azavea/iow-boundary-tool/pull/198)
+- Update Download, Replace Polygon Workflows [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
 
 ### Fixed
 

--- a/src/app/src/components/AfterSubmitModal.js
+++ b/src/app/src/components/AfterSubmitModal.js
@@ -17,7 +17,7 @@ import { DownloadIcon, LogoutIcon } from '@heroicons/react/outline';
 import { CheckCircleIcon } from '@heroicons/react/solid';
 
 import { useBoundaryId } from '../hooks';
-import { downloadData, getBoundaryShapeFilename } from '../utils';
+import { downloadData } from '../utils';
 import { logout } from '../store/authSlice';
 import { useDrawBoundary } from './DrawContext';
 
@@ -80,7 +80,7 @@ export default function AfterSubmitModal({ isOpen, onClose }) {
                             onClick={() => {
                                 downloadData(
                                     JSON.stringify(boundary.submission.shape),
-                                    getBoundaryShapeFilename(boundary)
+                                    `${boundary.official_name}.geojson`
                                 );
                             }}
                         >

--- a/src/app/src/components/DrawTools/DeletePolygonConfirmModal.js
+++ b/src/app/src/components/DrawTools/DeletePolygonConfirmModal.js
@@ -7,6 +7,7 @@ import {
     AlertDialogFooter,
     Button,
     Flex,
+    Heading,
     Spacer,
 } from '@chakra-ui/react';
 import { useBoundaryId, useEndpointToastError } from '../../hooks';
@@ -30,7 +31,9 @@ export default function DeletePolygonConfirmModal({ isOpen, onClose }) {
             <AlertDialogOverlay>
                 <AlertDialogContent>
                     <AlertDialogHeader textAlign='center' m={4} mb={2}>
-                        Are you sure you want to delete the current polygon?
+                        <Heading size='md'>
+                            Are you sure you want to delete the current polygon?
+                        </Heading>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
                         <Flex w='100%' m={4} mt={2}>

--- a/src/app/src/components/DrawTools/EditPolygonModal.js
+++ b/src/app/src/components/DrawTools/EditPolygonModal.js
@@ -8,8 +8,6 @@ import {
     ModalContent,
     ModalHeader,
     ModalFooter,
-    Input,
-    ModalBody,
 } from '@chakra-ui/react';
 import { CloudUploadIcon } from '@heroicons/react/outline';
 
@@ -17,7 +15,7 @@ import { ACCEPT_SHAPES } from '../../constants';
 import { useBoundaryId, useFilePicker } from '../../hooks';
 import { useReplaceBoundaryShapeMutation } from '../../api/boundaries';
 
-export default function EditPolygonModal({ isOpen, label, onClose }) {
+export default function EditPolygonModal({ isOpen, onClose }) {
     const [replaceShape, { isLoading }] = useReplaceBoundaryShapeMutation();
     const id = useBoundaryId();
 
@@ -35,28 +33,25 @@ export default function EditPolygonModal({ isOpen, label, onClose }) {
             <ModalOverlay>
                 <ModalContent>
                     <ModalHeader textAlign='center' m={4} mb={2}>
-                        Edit polygon
+                        Replace polygon
                     </ModalHeader>
-                    <ModalBody mx={4}>
-                        <Input value={label} disabled />
-                    </ModalBody>
                     <ModalFooter>
                         <Flex w='100%' m={4} mt={2}>
                             <Button
                                 variant='secondary'
-                                leftIcon={<Icon as={CloudUploadIcon} />}
-                                onClick={openFileDialog}
-                                isLoading={isLoading}
-                            >
-                                Upload File
-                            </Button>
-                            <Spacer />
-                            <Button
-                                variant='cta'
                                 onClick={onClose}
                                 disabled={isLoading}
                             >
                                 Cancel
+                            </Button>
+                            <Spacer />
+                            <Button
+                                variant='cta'
+                                leftIcon={<Icon as={CloudUploadIcon} />}
+                                onClick={openFileDialog}
+                                isLoading={isLoading}
+                            >
+                                Upload new file
                             </Button>
                         </Flex>
                     </ModalFooter>

--- a/src/app/src/components/DrawTools/EditPolygonModal.js
+++ b/src/app/src/components/DrawTools/EditPolygonModal.js
@@ -2,6 +2,7 @@ import {
     Button,
     Flex,
     Spacer,
+    Heading,
     Icon,
     Modal,
     ModalOverlay,
@@ -33,7 +34,7 @@ export default function EditPolygonModal({ isOpen, onClose }) {
             <ModalOverlay>
                 <ModalContent>
                     <ModalHeader textAlign='center' m={4} mb={2}>
-                        Replace polygon
+                        <Heading size='md'>Replace polygon</Heading>
                     </ModalHeader>
                     <ModalFooter>
                         <Flex w='100%' m={4} mt={2}>

--- a/src/app/src/components/DrawTools/EditToolbar.js
+++ b/src/app/src/components/DrawTools/EditToolbar.js
@@ -132,7 +132,7 @@ function PolygonButton({ openEditDialog }) {
     if (!canWrite) {
         return (
             <Button variant='toolbar' minW={POLYGON_BUTTON_WIDTH} disabled>
-                {boundary.name}
+                {boundary.utility.name}
             </Button>
         );
     }
@@ -156,7 +156,7 @@ function PolygonButton({ openEditDialog }) {
                 variant='toolbar'
                 minW={POLYGON_BUTTON_WIDTH}
             >
-                {boundary.name}
+                Replace polygon
             </Button>
         );
     }

--- a/src/app/src/components/Submissions/Badges.js
+++ b/src/app/src/components/Submissions/Badges.js
@@ -5,7 +5,7 @@ import { BOUNDARY_STATUS } from '../../constants';
 const BADGE_COLORS = {
     [BOUNDARY_STATUS.DRAFT]: 'gray',
     [BOUNDARY_STATUS.SUBMITTED]: 'teal',
-    [BOUNDARY_STATUS.IN_REVIEW]: 'orange',
+    [BOUNDARY_STATUS.IN_REVIEW]: 'yellow',
     [BOUNDARY_STATUS.NEEDS_REVISIONS]: 'orange',
     [BOUNDARY_STATUS.APPROVED]: 'green',
 };

--- a/src/app/src/components/Submissions/Detail/Detail.js
+++ b/src/app/src/components/Submissions/Detail/Detail.js
@@ -122,7 +122,7 @@ export default function SubmissionDetail() {
                             onClick={() => navigate('/submissions')}
                         />
                         <Heading size='lg' mr={6}>
-                            {boundary.name}
+                            {boundary.utility.name}
                         </Heading>
                         <StatusBadge status={boundary.status} fixedHeight />
                     </Flex>

--- a/src/app/src/components/Submissions/Detail/Map.js
+++ b/src/app/src/components/Submissions/Detail/Map.js
@@ -1,4 +1,4 @@
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Box, Button, Flex, HStack, Icon, Text } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -24,6 +24,7 @@ import {
 } from '../../../constants';
 import { useMapLayer } from '../../../hooks';
 import { downloadData, getBoundaryPermissions } from '../../../utils';
+import { setHasZoomedToShape } from '../../../store/mapSlice';
 
 export default function Map({ boundary, startReview, createDraft }) {
     const StatusBar = useSubmissionStatusBar(boundary);
@@ -95,13 +96,17 @@ function MapButtons({ boundary, startReview, createDraft }) {
 
 function DrawButton({ boundary, startReview, createDraft }) {
     const navigate = useNavigate();
+    const dispatch = useDispatch();
     const user = useSelector(state => state.auth.user);
     const { canWrite, canReview, canCreateDraft } = getBoundaryPermissions({
         boundary,
         user,
     });
 
-    const goToDrawPage = () => navigate(`/draw/${boundary.id}`);
+    const goToDrawPage = () => {
+        dispatch(setHasZoomedToShape(false));
+        navigate(`/draw/${boundary.id}`);
+    };
 
     let label = 'View boundary';
     let icon = EyeIcon;

--- a/src/app/src/components/Submissions/Detail/Map.js
+++ b/src/app/src/components/Submissions/Detail/Map.js
@@ -23,11 +23,7 @@ import {
     ROLES,
 } from '../../../constants';
 import { useMapLayer } from '../../../hooks';
-import {
-    downloadData,
-    getBoundaryShapeFilename,
-    getBoundaryPermissions,
-} from '../../../utils';
+import { downloadData, getBoundaryPermissions } from '../../../utils';
 
 export default function Map({ boundary, startReview, createDraft }) {
     const StatusBar = useSubmissionStatusBar(boundary);
@@ -85,7 +81,7 @@ function MapButtons({ boundary, startReview, createDraft }) {
                         onClick={() =>
                             downloadData(
                                 JSON.stringify(boundary.submission.shape),
-                                getBoundaryShapeFilename(boundary)
+                                `${boundary.official_name}.geojson`
                             )
                         }
                     >

--- a/src/app/src/utils.js
+++ b/src/app/src/utils.js
@@ -97,21 +97,6 @@ export function downloadData(data, filename = null) {
     a.remove();
 }
 
-export function getBoundaryShapeFilename(boundary) {
-    const now = new Date();
-
-    const year = now.getFullYear();
-    const month = now.getMonth().toString().padStart(2, '0');
-    const date = now.getDate().toString().padStart(2, '0');
-
-    return `${[
-        year,
-        month,
-        date,
-        boundary.utility.name.replaceAll(/\s+/g, '_'),
-    ].join('_')}.geojson`;
-}
-
 export function fileIsImageFile(file) {
     return (
         REFERENCE_IMAGE_FILE_EXTENSIONS.some(extension =>

--- a/src/django/api/models/boundary.py
+++ b/src/django/api/models/boundary.py
@@ -83,3 +83,14 @@ class Boundary(models.Model):
             return recent_submissions[1]
 
         return None
+
+    @cached_property
+    def official_name(self):
+        prefix = f"{self.utility.pwsid}_{self.utility.compact_name}"
+
+        if self.status == BOUNDARY_STATUS.DRAFT:
+            suffix = "UNSUBMITTED"
+        else:
+            suffix = self.latest_submission.submitted_at.strftime('%Y%m%d')
+
+        return f"{prefix}_{suffix}"

--- a/src/django/api/models/utility.py
+++ b/src/django/api/models/utility.py
@@ -1,6 +1,7 @@
 from django.contrib.gis.db import models as gis_models
 from django.contrib.gis.geos import Point
 from django.db import models
+from django.utils.functional import cached_property
 
 from .state import State
 
@@ -26,3 +27,10 @@ class Utility(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.pwsid})"
+
+    @cached_property
+    def compact_name(self):
+        alphanum_name = "".join(c for c in self.name if c.isalnum())
+        alphanum_city = "".join(c for c in self.address_city if c.isalnum())
+
+        return f"{alphanum_name}{alphanum_city}"

--- a/src/django/api/serializers/boundary.py
+++ b/src/django/api/serializers/boundary.py
@@ -126,6 +126,7 @@ class BoundaryDetailSerializer(ModelSerializer):
         model = Boundary
         fields = [
             'name',
+            'official_name',
             'utility',
             'status',
             'submission',


### PR DESCRIPTION
## Overview

Removes the boundary name throughout the user interface. The field is left in the back-end for now.

It is replaced by the utility name in the Boundary Details page. In the Draw page, we now see a Replace polygon message, with the modal updated accordingly.

There is also a new `official_name` property of the boundary, which is a string of the format `{PWSID}_{UtilityNameAndCity}_{SubmittedAt}`. For boundaries that are not yet submitted, we use `UNSUBMITTED` instead of `SubmittedAt`. Currently, the only place this is used is to name the downloaded file.

Also fixes a small bug that had broken the zoom-to-shape functionality in the Draw page.

Closes #91 
Closes #187 

### Demo

![image](https://user-images.githubusercontent.com/1430060/201431132-0342c2ed-91ee-40b8-836d-361f6739deb8.png)

![image](https://user-images.githubusercontent.com/1430060/201433304-8ba6bf2e-0e1b-499c-86f5-3b254a52c172.png)

## Testing Instructions

- Open the Draw page http://localhost:4545/draw/1
  - [x] Ensure you don't see the boundary name
  - [x] Ensure replacing the polygon works as expected
- Open the Details page http://localhost:4545/submissions/1
  - [x] Ensure you see the utility name as the title
  - [x] Ensure that if you download the file, it has the `official_name` for both DRAFT and SUBMITTED+ boundaries
  - [x] Ensure the Draw page is zoomed to the shape when you navigate to it

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
