### PR TITLE
Add contributor emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add submit boundary validator email [#201](https://github.com/azavea/iow-boundary-tool/pull/201)
 - Add Yellow color for In Review submissions [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
 - Add reference image opacity slider [#204](https://github.com/azavea/iow-boundary-tool/pull/204)
+- Add contributor email notifications [#203](https://github.com/azavea/iow-boundary-tool/pull/203)
 
 ### Changed
 

--- a/src/django/api/mail.py
+++ b/src/django/api/mail.py
@@ -9,38 +9,94 @@ from .models.user import Roles
 logger = logging.getLogger(__name__)
 
 
-def send_boundary_submitted_validator_email(request, updated_boundary):
-    subj_template = get_template('mail/boundary_submitted_validator_subject.txt')
-    body_template = get_template('mail/boundary_submitted_validator_body.txt')
+def send_boundary_submitted_validator_email(request, boundary):
+    (subject, body) = get_boundary_subject_and_body(
+        request,
+        boundary,
+        subj_template_name='mail/boundary_submitted_validator_subject.txt',
+        body_template_name='mail/boundary_submitted_validator_body.txt',
+    )
 
-    validators = updated_boundary.utility.state.users.filter(role=Roles.VALIDATOR)
+    validators = boundary.utility.state.users.filter(role=Roles.VALIDATOR)
     validator_emails = [user.email for user in validators.only('email')]
 
-    template_data = {
-        "city": updated_boundary.utility.address_city,
-        "pwsid": updated_boundary.utility.pwsid,
-        "details_link": "{}/submissions/{}/".format(
-            make_iow_url(request),
-            updated_boundary.id,
-        ),
-    }
+    for email in validator_emails:
+        safe_send_single_recipient_mail(subject, body, recipient=email)
+
+
+def send_boundary_submitted_contributor_email(request, boundary):
+    (subject, body) = get_boundary_subject_and_body(
+        request,
+        boundary,
+        subj_template_name='mail/boundary_submitted_contributor_subject.txt',
+        body_template_name='mail/boundary_submitted_contributor_body.txt',
+    )
+
+    for recipient in get_boundary_contributor_emails(boundary):
+        safe_send_single_recipient_mail(subject, body, recipient)
+
+
+def send_boundary_needs_revision_email(request, boundary):
+    (subject, body) = get_boundary_subject_and_body(
+        request,
+        boundary,
+        subj_template_name='mail/boundary_needs_revisions_subject.txt',
+        body_template_name='mail/boundary_needs_revisions_body.txt',
+    )
+
+    for recipient in get_boundary_contributor_emails(boundary):
+        safe_send_single_recipient_mail(subject, body, recipient)
+
+
+def send_boundary_approved_email(request, boundary):
+    (subject, body) = get_boundary_subject_and_body(
+        request,
+        boundary,
+        subj_template_name='mail/boundary_approved_subject.txt',
+        body_template_name='mail/boundary_approved_body.txt',
+    )
+
+    for recipient in get_boundary_contributor_emails(boundary):
+        safe_send_single_recipient_mail(subject, body, recipient)
+
+
+def get_boundary_subject_and_body(
+    request,
+    boundary,
+    subj_template_name,
+    body_template_name,
+):
+    subj_template = get_template(subj_template_name)
+    body_template = get_template(body_template_name)
+
+    template_data = get_boundary_template_data(request, boundary)
 
     subject = subj_template.render(template_data)
     body = body_template.render(template_data)
 
-    for email in validator_emails:
-        try:
-            send_mail(
-                subject,
-                body,
-                from_email=None,
-                recipient_list=[email],
-            )
-        except Exception as exception:
-            logger.error(
-                'Could not send validator update email to %s. Caught exception:\n%s',
-                (email, exception),
-            )
+    return (subject, body)
+
+
+def get_boundary_template_data(request, boundary):
+    data = {
+        "utility_name": boundary.utility.name,
+        "pwsid": boundary.utility.pwsid,
+        "details_link": "{}/submissions/{}/".format(
+            make_iow_url(request),
+            boundary.id,
+        ),
+    }
+
+    if hasattr(boundary.latest_submission, 'review'):
+        data['review_notes'] = boundary.latest_submission.review.notes
+
+    return data
+
+
+def get_boundary_contributor_emails(boundary):
+    return boundary.utility.users.filter(role=Roles.CONTRIBUTOR).values_list(
+        "email", flat=True
+    )
 
 
 def make_iow_url(request):
@@ -52,3 +108,23 @@ def make_iow_url(request):
         host = request.get_host()
 
     return f'{protocol}://{host}'
+
+
+def safe_send_single_recipient_mail(subject, body, recipient):
+    try:
+        send_mail(subject, body, from_email=None, recipient_list=[recipient])
+    except Exception as exception:
+        logger.error(
+            "\n".join(
+                [
+                    'Could not send the following email:',
+                    f'To: {recipient}',
+                    f'Subject: {subject}',
+                    'Body:',
+                    body,
+                    '',
+                    'Caught exception:',
+                    str(exception),
+                ]
+            ),
+        )

--- a/src/django/api/templates/mail/boundary_approved_body.txt
+++ b/src/django/api/templates/mail/boundary_approved_body.txt
@@ -1,0 +1,6 @@
+Submission has been approved - {{utility_name}} {{pwsid}}
+
+The boundary you submitted has been approved!
+
+View details:
+{{ details_link }}

--- a/src/django/api/templates/mail/boundary_approved_subject.txt
+++ b/src/django/api/templates/mail/boundary_approved_subject.txt
@@ -1,0 +1,1 @@
+Submission has been approved - {{utility_name}} {{pwsid}}

--- a/src/django/api/templates/mail/boundary_needs_revisions_body.txt
+++ b/src/django/api/templates/mail/boundary_needs_revisions_body.txt
@@ -1,0 +1,8 @@
+Submission needs revisions - {{utility_name}} {{pwsid}}
+
+The boundary you submitted has been marked-up with revisions.
+
+    {{ review_notes }}
+
+Follow the link below to refine the boundary drawing.
+{{ details_link }}

--- a/src/django/api/templates/mail/boundary_needs_revisions_subject.txt
+++ b/src/django/api/templates/mail/boundary_needs_revisions_subject.txt
@@ -1,0 +1,1 @@
+Submission needs revisions - {{utility_name}} {{pwsid}}

--- a/src/django/api/templates/mail/boundary_submitted_contributor_body.txt
+++ b/src/django/api/templates/mail/boundary_submitted_contributor_body.txt
@@ -1,0 +1,6 @@
+Boundary submitted - {{utility_name}} {{pwsid}}
+
+Your boundary has been submitted.
+
+View details:
+{{ details_link }}

--- a/src/django/api/templates/mail/boundary_submitted_contributor_subject.txt
+++ b/src/django/api/templates/mail/boundary_submitted_contributor_subject.txt
@@ -1,0 +1,1 @@
+Boundary submitted - {{utility_name}} {{pwsid}}

--- a/src/django/api/templates/mail/boundary_submitted_validator_body.txt
+++ b/src/django/api/templates/mail/boundary_submitted_validator_body.txt
@@ -1,4 +1,4 @@
-Submission for review - {{city}} {{pwsid}}
+Submission for review - {{utility_name}} {{pwsid}}
 
 A new boundary has been submitted for review.
 

--- a/src/django/api/templates/mail/boundary_submitted_validator_subject.txt
+++ b/src/django/api/templates/mail/boundary_submitted_validator_subject.txt
@@ -1,1 +1,1 @@
-Submission for review - {{city}} {{pwsid}}
+Submission for review - {{utility_name}} {{pwsid}}

--- a/src/django/api/views/boundary.py
+++ b/src/django/api/views/boundary.py
@@ -10,7 +10,11 @@ from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.views import APIView
 
 from ..exceptions import BadRequestException
-from ..mail import send_boundary_submitted_validator_email
+from ..mail import (
+    send_boundary_approved_email,
+    send_boundary_submitted_contributor_email,
+    send_boundary_submitted_validator_email,
+)
 from ..models import ReferenceImage, Roles, Submission
 from ..models.boundary import BOUNDARY_STATUS, Boundary
 from ..models.submission import Approval
@@ -158,6 +162,7 @@ class BoundarySubmitView(APIView):
         boundary.latest_submission.save()
 
         send_boundary_submitted_validator_email(request, boundary)
+        send_boundary_submitted_contributor_email(request, boundary)
 
         return Response(status=HTTP_204_NO_CONTENT)
 
@@ -260,6 +265,8 @@ class BoundaryApproveView(BoundaryView):
         self.check_boundary_is_approvable(boundary, request.user.role)
 
         boundary.latest_submission.approvals.create(approved_by=request.user)
+
+        send_boundary_approved_email(request, boundary)
 
         return Response(status=HTTP_204_NO_CONTENT)
 

--- a/src/django/api/views/review.py
+++ b/src/django/api/views/review.py
@@ -5,6 +5,7 @@ from rest_framework.status import HTTP_204_NO_CONTENT
 from rest_framework.views import APIView
 
 from ..exceptions import BadRequestException
+from ..mail import send_boundary_needs_revision_email
 from ..models.boundary import BOUNDARY_STATUS
 from ..models.submission import Review
 from ..permissions import UserCanReviewBoundaries
@@ -48,5 +49,7 @@ class ReviewFinishView(ReviewView):
         review.notes = request.data.get('notes', '')
         review.finish(request.user)
         review.save()
+
+        send_boundary_needs_revision_email(request, boundary)
 
         return Response(status=HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## Overview

This PR adds three contributor emails:
- Boundary has been submitted
- Boundary needs revisions
- Boundary has been approved

Closes #161 

## Notes

I set the boundary submitted email to go to the `submitted_by` user of the submission, but perhaps `created_by` would make more sense.

## Testing Instructions

- Login as a1@azavea.com
- Submit a boundary
  - [x] Ensure validator boundary submitted email appears in server console
  - [x] Ensure contributor boundary submitted email appears in server console
- Review a submission
  - [x] Ensure contributor needs revisions email appears in server console
- Approve a boundary
  - [x] Ensure contributor approval email appears in server console
 
## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
