### PR TITLE
Update user admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Yellow color for In Review submissions [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
 - Add reference image opacity slider [#204](https://github.com/azavea/iow-boundary-tool/pull/204)
 - Add contributor email notifications [#203](https://github.com/azavea/iow-boundary-tool/pull/203)
+- Add contact info and send password reset email to user admin page [#208](https://github.com/azavea/iow-boundary-tool/pull/208)
 
 ### Changed
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -10,6 +10,17 @@ from .models.state import State
 from .models.submission import Annotation, Approval, Review, Submission
 from .models.user import User, Utility
 
+contact_info_field_set = (
+    "Contact Info",
+    {
+        "fields": (
+            "full_name",
+            "phone_number",
+            "job_title",
+        )
+    },
+)
+
 
 class EmailAsUsernameUserAdmin(UserAdmin):
     list_display = ("email", "is_staff")
@@ -40,6 +51,7 @@ class EmailAsUsernameUserAdmin(UserAdmin):
                 ),
             },
         ),
+        contact_info_field_set,
     )
     add_fieldsets = (
         (
@@ -55,6 +67,7 @@ class EmailAsUsernameUserAdmin(UserAdmin):
                 ),
             },
         ),
+        contact_info_field_set,
     )
     readonly_fields = ('send_password_reset_email',)
 

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.urls import reverse
+from django.utils.html import format_html
 from rest_framework.authtoken.models import TokenProxy
 
 from .models.boundary import Boundary
@@ -15,7 +17,19 @@ class EmailAsUsernameUserAdmin(UserAdmin):
     ordering = ("email",)
 
     fieldsets = (
-        (None, {"fields": ("email", "password", "role", "utilities", "states")}),
+        (
+            None,
+            {
+                "fields": (
+                    "email",
+                    "password",
+                    "role",
+                    "utilities",
+                    "states",
+                    "send_password_reset_email",
+                )
+            },
+        ),
         (
             "Permissions",
             {
@@ -42,6 +56,14 @@ class EmailAsUsernameUserAdmin(UserAdmin):
             },
         ),
     )
+    readonly_fields = ('send_password_reset_email',)
+
+    def send_password_reset_email(self, user):
+        props = 'href="{}" style="padding: 8px;" class="button"'.format(
+            reverse('send-password-reset', kwargs={"user_id": user.id})
+        )
+
+        return format_html(f'<a {props}>Send password reset email</a>')
 
 
 submission_stage_models = [

--- a/src/django/api/templates/mail/new_user_password_reset_body.txt
+++ b/src/django/api/templates/mail/new_user_password_reset_body.txt
@@ -1,0 +1,4 @@
+A Boundary Sync account has been created for you
+
+Login to set your password
+{{ reset_link }}

--- a/src/django/api/templates/mail/new_user_password_reset_subject.txt
+++ b/src/django/api/templates/mail/new_user_password_reset_subject.txt
@@ -1,0 +1,1 @@
+A Boundary Sync account has been created for you

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -3,6 +3,7 @@ from rest_framework.urlpatterns import format_suffix_patterns
 
 from .views import Login, Logout
 from .views.annotations import AnnotationCreateView, AnnotationUpdateView
+from .views.auth import SendPasswordResetEmailView
 from .views.boundary import (
     BoundaryApproveView,
     BoundaryDetailView,
@@ -18,6 +19,11 @@ from .views.review import ReviewCreateView, ReviewFinishView
 urlpatterns = [
     path("auth/login/", Login.as_view()),
     path("auth/logout/", Logout.as_view()),
+    path(
+        "auth/user/<int:user_id>/reset-password/",
+        SendPasswordResetEmailView.as_view(),
+        name='send-password-reset',
+    ),
     path("auth/", include("dj_rest_auth.urls")),
     path("boundaries/", BoundaryListView.as_view(), name="boundary_list"),
     path("boundaries/<int:id>/", BoundaryDetailView.as_view()),

--- a/src/django/api/views/auth.py
+++ b/src/django/api/views/auth.py
@@ -1,13 +1,20 @@
 from dj_rest_auth.views import LoginView, LogoutView
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.messages import SUCCESS, add_message
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from rest_framework import status
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from ..mail import send_new_user_password_reset_email
+from ..models import User
 from ..serializers import UserSerializer
 
 
@@ -49,3 +56,16 @@ class Logout(LogoutView):
         logout(request)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class SendPasswordResetEmailView(APIView):
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, user_id, format=None):
+        user = get_object_or_404(User, pk=user_id)
+
+        send_new_user_password_reset_email(request, user)
+
+        add_message(request, SUCCESS, 'Password reset email sent!')
+
+        return HttpResponseRedirect(reverse('admin:api_user_change', args=[user.id]))


### PR DESCRIPTION
## Overview

This PR adds two features to the user admin page
- Send password reset email
- Contact info fields

Closes #192 

### Notes

#192 asks for user address on this page, but we don't have this field in the database. 

## Testing Instructions

- [x] Ensure admin can create a new user
- [x] Ensure that admins can send a password reset email for a user
- [x] Ensure that email contains the correct reset link
- [x] Ensure that contact info can be edited on the user admin page

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
