### PR TITLE
Change draw page url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only redirect to /welcome for new boundaries [#175](https://github.com/azavea/iow-boundary-tool/pull/175)
 - Update File Upload UI [#198](https://github.com/azavea/iow-boundary-tool/pull/198)
 - Update Download, Replace Polygon Workflows [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
+- Change draw page URL [#209](https://github.com/azavea/iow-boundary-tool/pull/209)
 
 ### Fixed
 

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -52,15 +52,7 @@ function PrivateRoutes() {
 
             <Route path='/submissions/*' element={<Submissions />} />
 
-            <Route
-                path='*'
-                element={
-                    <Navigate
-                        to={hasWelcomePageAccess ? '/welcome' : '/submissions'}
-                        replace
-                    />
-                }
-            />
+            <Route path='*' element={<Navigate to='/submissions' replace />} />
         </Routes>
     );
 }

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -1,21 +1,12 @@
 import { useSelector } from 'react-redux';
-import {
-    BrowserRouter,
-    Outlet,
-    Navigate,
-    Routes,
-    Route,
-} from 'react-router-dom';
+import { BrowserRouter, Navigate, Routes, Route } from 'react-router-dom';
 
 import './App.css';
 import Login from './pages/Login';
 import ForgotPassword from './pages/ForgotPassword';
 import ResetPassword from './pages/ResetPassword';
 import Welcome from './pages/Welcome';
-import Draw from './pages/Draw';
 import Submissions from './pages/Submissions';
-import NotFound from './pages/NotFound';
-import NavBar from './components/NavBar';
 
 import AuthenticationGuard from './components/AuthenticationGuard';
 import UtilityGuard from './components/UtilityGuard';
@@ -54,35 +45,23 @@ function PrivateRoutes() {
     const hasWelcomePageAccess = userRole === ROLES.CONTRIBUTOR;
 
     return (
-        <>
-            <Routes>
-                <Route path='/draw/*' element={<NavBar />} />
-                <Route path='/submissions/*' element={<NavBar />} />
-                <Route path='*' element={<Outlet />} />
-            </Routes>
+        <Routes>
+            {hasWelcomePageAccess && (
+                <Route path='/welcome' element={<Welcome />} />
+            )}
 
-            <Routes>
-                {hasWelcomePageAccess && (
-                    <Route path='/welcome' element={<Welcome />} />
-                )}
-                <Route path='/draw' element={<NotFound />} />
-                <Route path='/draw/:boundaryId' element={<Draw />} />
-                <Route path='/submissions/*' element={<Submissions />} />
-                <Route
-                    path='*'
-                    element={
-                        <Navigate
-                            to={
-                                hasWelcomePageAccess
-                                    ? '/welcome'
-                                    : '/submissions'
-                            }
-                            replace
-                        />
-                    }
-                />
-            </Routes>
-        </>
+            <Route path='/submissions/*' element={<Submissions />} />
+
+            <Route
+                path='*'
+                element={
+                    <Navigate
+                        to={hasWelcomePageAccess ? '/welcome' : '/submissions'}
+                        replace
+                    />
+                }
+            />
+        </Routes>
     );
 }
 

--- a/src/app/src/components/AuthenticationGuard.js
+++ b/src/app/src/components/AuthenticationGuard.js
@@ -35,7 +35,12 @@ export default function AuthenticationGuard({ children }) {
         return (
             <Navigate
                 to='/login'
-                state={{ pathname: location.pathname, search: location.search }}
+                state={
+                    location.pathname !== '/' && {
+                        pathname: location.pathname,
+                        search: location.search,
+                    }
+                }
             />
         );
     }

--- a/src/app/src/components/ModalSections/FileUpload.js
+++ b/src/app/src/components/ModalSections/FileUpload.js
@@ -66,7 +66,7 @@ export default function FileUpload({ PreviousButton }) {
             shape: shapeFiles?.[0],
         })
             .unwrap()
-            .then(id => navigate(`/draw/${id}`));
+            .then(id => navigate(`/submissions/${id}/draw`));
     };
 
     return (

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -8,26 +8,20 @@ import {
     Spacer,
 } from '@chakra-ui/react';
 import { useDispatch } from 'react-redux';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { ArrowLeftIcon, CogIcon, LogoutIcon } from '@heroicons/react/outline';
 import apiClient from '../api/client';
 import { API_URLS, NAVBAR_HEIGHT } from '../constants';
 import { logout } from '../store/authSlice';
 import UtilityControl from './UtilityControl';
+import { useBoundaryId } from '../hooks';
 
-const NAVBAR_VARIANTS = {
+export const NAVBAR_VARIANTS = {
     DRAW: 'draw',
     SUBMISSION: 'submission',
 };
 
-export default function NavBar() {
-    const location = useLocation();
-
-    let variant = NAVBAR_VARIANTS.SUBMISSION;
-    if (location.pathname.startsWith('/draw')) {
-        variant = NAVBAR_VARIANTS.DRAW;
-    }
-
+export default function NavBar({ variant }) {
     return (
         <SimpleGrid
             columns={3}
@@ -73,9 +67,7 @@ function SettingsButton({ variant }) {
 function ExitButton({ variant }) {
     const navigate = useNavigate();
     const dispatch = useDispatch();
-    const { '*': params } = useParams();
-
-    const boundaryId = params.startsWith('draw/') ? params.substring(5) : '';
+    const boundaryId = useBoundaryId();
 
     return variant === NAVBAR_VARIANTS.SUBMISSION ? (
         <Button

--- a/src/app/src/components/Submissions/Detail/Detail.js
+++ b/src/app/src/components/Submissions/Detail/Detail.js
@@ -9,7 +9,7 @@ import {
     VStack,
 } from '@chakra-ui/react';
 import { ArrowLeftIcon } from '@heroicons/react/outline';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
     useApproveBoundaryMutation,
     useGetBoundaryDetailsQuery,
@@ -22,7 +22,7 @@ import ActivityLog from '../ActivityLog';
 import { StatusBadge } from '../Badges';
 import Info from './Info';
 import Map from './Map';
-import { useEndpointToastError } from '../../../hooks';
+import { useBoundaryId, useEndpointToastError } from '../../../hooks';
 import { useStartReviewMutation } from '../../../api/reviews';
 import { useCreateDraftMutation } from '../../../api/boundaries';
 import { NAVBAR_HEIGHT } from '../../../constants';
@@ -31,7 +31,7 @@ import { getBoundaryPermissions, heroToChakraIcon } from '../../../utils';
 
 export default function SubmissionDetail() {
     const navigate = useNavigate();
-    const { id } = useParams();
+    const id = useBoundaryId();
     const user = useSelector(state => state.auth.user);
 
     const {

--- a/src/app/src/components/Submissions/Detail/Map.js
+++ b/src/app/src/components/Submissions/Detail/Map.js
@@ -105,7 +105,7 @@ function DrawButton({ boundary, startReview, createDraft }) {
 
     const goToDrawPage = () => {
         dispatch(setHasZoomedToShape(false));
-        navigate(`/draw/${boundary.id}`);
+        navigate(`/submissions/${boundary.id}/draw`);
     };
 
     let label = 'View boundary';

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import {
     HStack,
     Box,
@@ -28,34 +27,42 @@ import {
     LocationMarkerIcon,
 } from '@heroicons/react/solid';
 import { useSelector } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { heroToChakraIcon } from '../../utils';
 import { useGetBoundariesQuery } from '../../api/boundaries';
 
 import { StatusBadge } from './Badges';
 import { ROLES } from '../../constants';
+import CenteredSpinner from '../CenteredSpinner';
 
 export default function SubmissionsList() {
     const navigate = useNavigate();
     const location = useLocation();
     const user = useSelector(state => state.auth.user);
     const utilityId = useSelector(state => state.auth.utility?.id);
+    const userIsContributor = user.role === ROLES.CONTRIBUTOR;
 
     const {
         isFetching,
+        isLoading,
         data: boundaries,
         error,
     } = useGetBoundariesQuery({
-        utilities: user.role === ROLES.CONTRIBUTOR ? utilityId : undefined,
+        utilities: userIsContributor ? utilityId : undefined,
     });
 
-    // Navigate to /welcome if coming from /login and no boundaries already
-    useEffect(() => {
-        if (boundaries?.length === 0 && location.state?.pathname === '/login') {
-            navigate('/welcome');
-        }
-    }, [location.state, boundaries, navigate]);
+    if (isLoading) {
+        return <CenteredSpinner />;
+    }
+
+    if (
+        userIsContributor &&
+        boundaries?.length === 0 &&
+        location.state?.pathname === '/login'
+    ) {
+        return <Navigate to='/welcome' replace />;
+    }
 
     return (
         <Box paddingLeft={8} paddingRight={8} mt={6}>

--- a/src/app/src/pages/Submissions.js
+++ b/src/app/src/pages/Submissions.js
@@ -1,11 +1,44 @@
 import { Routes, Route } from 'react-router-dom';
+import NavBar, { NAVBAR_VARIANTS } from '../components/NavBar';
 import { List, Detail } from '../components/Submissions';
+import Draw from './Draw';
 
 export default function Submissions() {
     return (
         <Routes>
-            <Route index element={<List />} />
-            <Route path=':id' element={<Detail />} />
+            <Route
+                index
+                element={
+                    <WithNavbar>
+                        <List />
+                    </WithNavbar>
+                }
+            />
+            <Route
+                path=':boundaryId'
+                element={
+                    <WithNavbar>
+                        <Detail />
+                    </WithNavbar>
+                }
+            />
+            <Route
+                path=':boundaryId/draw'
+                element={
+                    <WithNavbar variant={NAVBAR_VARIANTS.DRAW}>
+                        <Draw />
+                    </WithNavbar>
+                }
+            />
         </Routes>
+    );
+}
+
+function WithNavbar({ variant = NAVBAR_VARIANTS.SUBMISSION, children }) {
+    return (
+        <>
+            <NavBar variant={variant} />
+            {children}
+        </>
     );
 }


### PR DESCRIPTION
## Overview

This PR moves the draw page into submissions: `/submissions/4/draw`. Doing this makes routing simpler and gives access to the boundary Id in the draw page navbar. This allows #205 to be fixed easily.

Also included in this PR is a fix for #206. This works by removing the default welcome page redirect and instead letting the submissions page be the sole determiner or whether or not a redirect to the welcome page should happen.

Closes #205 
Closes #206 

### Notes

The redirect from submissions to welcome does cause some of the components from the submissions page to appear briefly. Addressing this might require more significant changes and could probably be a part of #172 and/or #184.

## Testing Instructions

- http://localhost:4545
- Login as contributor
- select "Azavea Test Utility"
  - [x] Ensure you are directed to the submissions page
- Log out
- http://localhost:4545
- Login as contributor
- select "Other Utility"
  - [x] Ensure you are directed to the welcome page
- Navigate around and make sure no links are broken
## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
