### PR TITLE
Memoize shape update functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix view submission details link destination [#174](https://github.com/azavea/iow-boundary-tool/pull/174)
 - Fix submit boundary [#195](https://github.com/azavea/iow-boundary-tool/pull/195)
 - Fix contributor welcome redirect [#197](https://github.com/azavea/iow-boundary-tool/pull/197)
+- Memoize shape update functions [#210](https://github.com/azavea/iow-boundary-tool/pull/210)
 
 ### Deprecated
 

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet-draw';
@@ -63,21 +63,27 @@ export default function useEditingPolygon() {
     const [updateShape] = useUpdateBoundaryShapeMutation();
 
     const updatePolygonFromDrawEvent = useTrailingDebounceCallback({
-        callback: event => {
-            updateShape({ id, shape: getShapeFromDrawEvent(event) });
-        },
-        immediateCallback: event => {
-            dispatch(
-                api.util.updateQueryData(
-                    'getBoundaryDetails',
-                    id,
-                    draftDetails => {
-                        draftDetails.submission.shape =
-                            getShapeFromDrawEvent(event);
-                    }
-                )
-            );
-        },
+        callback: useCallback(
+            event => {
+                updateShape({ id, shape: getShapeFromDrawEvent(event) });
+            },
+            [id, updateShape]
+        ),
+        immediateCallback: useCallback(
+            event => {
+                dispatch(
+                    api.util.updateQueryData(
+                        'getBoundaryDetails',
+                        id,
+                        draftDetails => {
+                            draftDetails.submission.shape =
+                                getShapeFromDrawEvent(event);
+                        }
+                    )
+                );
+            },
+            [id, dispatch]
+        ),
         interval: DEBOUNCE_INTERVAL,
     });
 


### PR DESCRIPTION
## Overview

Memoizing these functions allows the `useTrailingDebounceCallback` to memoize its returned callback. This prevents the editing polygon layer from re-rendering each time its containing hook is called.

Closes #207 

### Notes

The reference images (which also use `useTrailingDebounceCallback`) don't need this fix because they aren't reactive to state updates.

## Testing Instructions

- Go the draw page in draft mode
- Edit the shape
- Before the debounced save shape request happens, click and hold one of the verticies
  - [x] Ensure the vertex doesn't jump back when the shave shape request happens

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
