### PR TITLE
Populate National Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Populate National Utilities [#215](https://github.com/azavea/iow-boundary-tool/pull/215)
+
 ### Changed
 
 ### Fixed

--- a/scripts/fetch-data
+++ b/scripts/fetch-data
@@ -19,6 +19,9 @@ STATE_BOUNDARIES_SHAPE_DIR=state_boundaries_shape
 STATE_BOUNDARIES_SHAPE_FILE=cb_2021_us_state_20m.shp
 STATE_BOUNDARIES_FILENAME=state_boundaries.geojson
 
+IOW_INITIALIZATION_BUCKET=s3://iow-boundary-tool-initialization-us-east-1
+UTILITIES_SQL=api_utility_20221121.sql
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     --force)
@@ -29,10 +32,14 @@ while [[ $# -gt 0 ]]; do
         DEV_MODE=Yes
         shift
         ;;
+    --utilities)
+        UTILITIES_MODE=Yes
+        shift
+        ;;
     --help)
         SHOW_USAGE=Yes
         shift
-        ;;      
+        ;;
   esac
 done
 
@@ -41,6 +48,7 @@ function usage() {
         "Usage: $(basename "$0")
     --force Force refetch of data even if it already exists.
     --dev   Fetch data not needed for build
+    --utilities Fetch utilities used in production
 Fetch data for this project.
 "
 }
@@ -100,6 +108,13 @@ function fetchMunicipalBoundariesData() {
     || : # Don't exit script if non-zero exit code
 }
 
+function fetchUtilities() {
+    aws --profile=iow-boundary-tool s3 cp $IOW_INITIALIZATION_BUCKET/$UTILITIES_SQL $DJANGO_DATA_DIR/
+    docker-compose run --entrypoint "/bin/bash -c" --rm django \
+        "PGHOST=\$POSTGRES_HOST PGDATABASE=\$POSTGRES_DB PGUSER=\$POSTGRES_USER PGPASSWORD=\$POSTGRES_PASSWORD \
+         psql --single-transaction --file=$DATA_DIR/$UTILITIES_SQL"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     if [ "$SHOW_USAGE" = "Yes" ]; then
         usage
@@ -109,6 +124,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 
         if [ "$DEV_MODE" = "Yes" ]; then
             fetchStateBoundariesData
+        fi
+
+        if [ "$UTILITIES_MODE" = "Yes" ]; then
+            fetchUtilities
         fi
     fi
 fi

--- a/src/app/src/components/Map.js
+++ b/src/app/src/components/Map.js
@@ -1,4 +1,5 @@
 import { MapContainer } from 'react-leaflet';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 
 import { MAP_CENTER, MAP_INITIAL_ZOOM, NAVBAR_HEIGHT } from '../constants';
@@ -6,6 +7,10 @@ import MapPanes from './MapPanes';
 
 export default function Map({ children }) {
     const location = useLocation();
+    const utility = useSelector(state => state.auth.utility);
+
+    const coordinates = utility?.location?.coordinates;
+    const center = coordinates ? [coordinates[1], coordinates[0]] : MAP_CENTER;
 
     // Anywhere but welcome activity, deduct height of nav bar
     const heightExpression = location.pathname.startsWith('/welcome')
@@ -14,7 +19,7 @@ export default function Map({ children }) {
 
     return (
         <MapContainer
-            center={MAP_CENTER}
+            center={center}
             zoom={MAP_INITIAL_ZOOM}
             zoomControl={false}
             style={{ height: heightExpression }}

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -13,7 +13,6 @@ export const POLYGON_LAYER_OPTIONS = {
 export const DATA_LAYERS = {
     PARCELS: { label: 'Parcel data', minZoom: 14 },
     MUNICIPAL_BOUNDARIES: { label: 'Municipal boundaries' },
-    POINTS_OF_INTEREST: { label: 'Points of interest' },
 };
 
 export const ESRI_ATTRIBUTION =

--- a/src/django/api/admin.py
+++ b/src/django/api/admin.py
@@ -79,6 +79,14 @@ class EmailAsUsernameUserAdmin(UserAdmin):
         return format_html(f'<a {props}>Send password reset email</a>')
 
 
+class UtilityAdmin(admin.ModelAdmin):
+    model = Utility
+    list_display = ('pwsid', 'name', 'address_city', 'state')
+    list_filter = (('state', admin.RelatedOnlyFieldListFilter),)
+    search_fields = ('name', 'pwsid', 'address_city')
+    ordering = ('pwsid',)
+
+
 submission_stage_models = [
     Boundary,
     ReferenceImage,
@@ -89,7 +97,7 @@ submission_stage_models = [
 ]
 
 admin.site.register(User, EmailAsUsernameUserAdmin)
-admin.site.register(Utility)
+admin.site.register(Utility, UtilityAdmin)
 admin.site.unregister(TokenProxy)
 admin.site.register(State)
 admin.site.register(submission_stage_models)

--- a/src/django/api/models/utility.py
+++ b/src/django/api/models/utility.py
@@ -26,7 +26,7 @@ class Utility(models.Model):
         verbose_name_plural = "utilities"
 
     def __str__(self):
-        return f"{self.name} ({self.pwsid})"
+        return f"{self.pwsid} - {self.name}"
 
     @cached_property
     def compact_name(self):


### PR DESCRIPTION
## Overview

The clients gave us a list of utilities to import. This is a national list, contains ~45K+ entries. This geojson file is here: https://drive.google.com/file/d/1iZT0ilvkVafIjMMRIasXEr0zeRH6ZKLl/view?usp=share_link.

Since our data model is different, I used jq to massage the geojson into something that matches our structure:

```bash
jq '{
    type,
    name,
    "features": [(
        .features[]
        | select(.geometry != null)
        | select(.properties.state_code | inside("AK","AL","AR","AZ","CA","CO","CT","DC","DE","FL","GA","HI","IA","ID","IL","IN","KS","KY","LA","MA","MD","ME","MI","MN","MO","MS","MT","NC","ND","NE","NH","NJ","NM","NV","NY","OH","OK","OR","PA","PR","RI","SC","SD","TN","TX","UT","VA","VT","WA","WI","WV","WY"))
        | {
            type,
            geometry,
            "properties": {
                "pwsid": .properties.pwsid,
                "name": .properties.pws_name,
                "state_id": .properties.state_code,
                "address_line_1": "",
                "address_line_2": "",
                "address_city": (.properties.city_served // ""),
                "address_zip_code": ""
            }
        }
    )]
}' scratch/pws_centroids_usa.geojson > scratch/utilities.geojson
```

The above also filters out utilities that don't have a location, and those that do not belong to the 50 official states.

Then I imported that geojson into my local database:

```bash
ogr2ogr -f 'PostgreSQL' PG:'host=localhost dbname=iow-boundary-tool user=iow-boundary-tool password=iow-boundary-tool' scratch/utilities.geojson -nln api_utility -append -geomfield location
```

I then edited the `docker-compose.override.yml` file to allow access into the database container:

```diff
diff --git a/docker-compose.override.yml b/docker-compose.override.yml
index c2610ab..6f8af0c 100644
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,10 @@
 version: "2.4"
 services:
+  database:
+    volumes:
+      - ./src/django/data:/usr/local/src
+    ports:
+      - 5432:5432
   app:
     ports:
       - 4545:4545
```

Then I went inside and `pg_dump`ed the table out:

```bash
docker compose exec database /bin/bash
cd /usr/local/src
pg_dump -U iow-boundary-tool -h localhost --table=api_utility --data-only > api_utility_20221121.sql
```

I manually removed the first two rows containing development / test utilities. Then I uploaded the file to a new S3 bucket:

```bash
aws --profile=iow-boundary-tool s3 ls iow-boundary-tool-initialization-us-east-1/
2022-11-21 17:36:06    4565611 api_utility_20221121.sql
```

I then `scp`d the file to staging and production and ran it there:

```bash
scp src/django/data/api_utility_20221121.sql iow-staging:
ssh iow-staging
sudo yum install postgresql
psql -h database.service.iow.internal -U iow iow -1 -f api_utility_20221121.sql
```

Also makes it so that the map initializes at the selected utility's location, rather than always in North Carolina.

Closes #196 

### Demo

![image](https://user-images.githubusercontent.com/1430060/203177172-0060394e-0dad-48ad-9af0-4b270640bf82.png)

https://user-images.githubusercontent.com/1430060/203181165-fdc0205d-c2bf-4281-8e4e-7da1769141a9.mp4

## Testing Instructions

- Check out this branch and run `server`
- If you have access to the AWS account, run the following:
    ```
    ./scripts/fetch-data --utilities
    ```
  - [x] Ensure this completes successfully
- Go to http://localhost:8181/admin/ and login as `a1@azavea.com` / `password`
- Go to http://localhost:8181/admin/api/utility/
  - [x] Ensure you see a lot of utilities

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
