### PR TITLE
Add Support for Exporting Boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add contributor email notifications [#203](https://github.com/azavea/iow-boundary-tool/pull/203)
 - Add contact info and send password reset email to user admin page [#208](https://github.com/azavea/iow-boundary-tool/pull/208)
 - Add production enviroment for ecsmanage [#214](https://github.com/azavea/iow-boundary-tool/pull/214)
+- Add Support for Exporting Boundaries [#218](https://github.com/azavea/iow-boundary-tool/pull/218)
 
 ### Changed
 
@@ -89,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Download, Replace Polygon Workflows [#202](https://github.com/azavea/iow-boundary-tool/pull/202)
 - Change draw page URL [#209](https://github.com/azavea/iow-boundary-tool/pull/209)
 - Upgrading to terraform 1.1.9 and creating deployment README [#213](https://github.com/azavea/iow-boundary-tool/pull/213)
+- Hide Add Map button for Validators [#218](https://github.com/azavea/iow-boundary-tool/pull/218)
+- Automatically determine utility at utility-specific URLs [#218](https://github.com/azavea/iow-boundary-tool/pull/218)
 
 ### Fixed
 
@@ -106,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix contributor welcome redirect [#197](https://github.com/azavea/iow-boundary-tool/pull/197)
 - Memoize shape update functions [#210](https://github.com/azavea/iow-boundary-tool/pull/210)
 - GitHub Actions permissions issue workaround [#219](https://github.com/azavea/iow-boundary-tool/pull/219)
+- Show correct utility in NavBar [#218](https://github.com/azavea/iow-boundary-tool/pull/218)
 
 ### Deprecated
 

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -17,7 +17,8 @@ import { useBoundaryId } from '../hooks';
 
 export const NAVBAR_VARIANTS = {
     DRAW: 'draw',
-    SUBMISSION: 'submission',
+    DETAIL: 'detail',
+    LIST: 'list',
 };
 
 export default function NavBar({ variant }) {
@@ -31,7 +32,7 @@ export default function NavBar({ variant }) {
             bg='gray.700'
         >
             <Flex align='center'>
-                <UtilityControl readOnly={variant === NAVBAR_VARIANTS.DRAW} />
+                <UtilityControl readOnly={variant !== NAVBAR_VARIANTS.LIST} />
             </Flex>
 
             <Flex align='center' justify='center'>
@@ -53,24 +54,38 @@ function ExitButton({ variant }) {
     const dispatch = useDispatch();
     const boundaryId = useBoundaryId();
 
-    return variant === NAVBAR_VARIANTS.SUBMISSION ? (
-        <Button
-            onClick={() => {
-                apiClient.post(API_URLS.LOGOUT, {}).then(() => {
-                    dispatch(logout());
-                    navigate('/login');
-                });
-            }}
-            rightIcon={<Icon as={LogoutIcon} />}
-        >
-            Log out
-        </Button>
-    ) : (
-        <Button
-            onClick={() => navigate(`/submissions/${boundaryId}`)}
-            rightIcon={<Icon as={ArrowLeftIcon} />}
-        >
-            Back
-        </Button>
-    );
+    switch (variant) {
+        case NAVBAR_VARIANTS.DRAW:
+            return (
+                <Button
+                    onClick={() => navigate(`/submissions/${boundaryId}`)}
+                    rightIcon={<Icon as={ArrowLeftIcon} />}
+                >
+                    Back
+                </Button>
+            );
+        case NAVBAR_VARIANTS.DETAIL:
+            return (
+                <Button
+                    onClick={() => navigate('/submissions/')}
+                    rightIcon={<Icon as={ArrowLeftIcon} />}
+                >
+                    Back
+                </Button>
+            );
+        default:
+            return (
+                <Button
+                    onClick={() => {
+                        apiClient.post(API_URLS.LOGOUT, {}).then(() => {
+                            dispatch(logout());
+                            navigate('/login');
+                        });
+                    }}
+                    rightIcon={<Icon as={LogoutIcon} />}
+                >
+                    Log out
+                </Button>
+            );
+    }
 }

--- a/src/app/src/components/NavBar.js
+++ b/src/app/src/components/NavBar.js
@@ -4,12 +4,11 @@ import {
     SimpleGrid,
     Heading,
     Icon,
-    IconButton,
     Spacer,
 } from '@chakra-ui/react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeftIcon, CogIcon, LogoutIcon } from '@heroicons/react/outline';
+import { ArrowLeftIcon, LogoutIcon } from '@heroicons/react/outline';
 import apiClient from '../api/client';
 import { API_URLS, NAVBAR_HEIGHT } from '../constants';
 import { logout } from '../store/authSlice';
@@ -43,25 +42,10 @@ export default function NavBar({ variant }) {
 
             <Flex align='center' gap={4}>
                 <Spacer />
-                <SettingsButton variant={variant} />
                 <ExitButton variant={variant} />
             </Flex>
         </SimpleGrid>
     );
-}
-
-function SettingsButton({ variant }) {
-    const navigate = useNavigate();
-
-    return variant === NAVBAR_VARIANTS.SUBMISSION ? (
-        <IconButton
-            icon={<Icon as={CogIcon} />}
-            aria-label='Settings'
-            onClick={() => {
-                navigate('/settings');
-            }}
-        />
-    ) : null;
 }
 
 function ExitButton({ variant }) {

--- a/src/app/src/components/Submissions/Detail/Detail.js
+++ b/src/app/src/components/Submissions/Detail/Detail.js
@@ -8,7 +8,11 @@ import {
     StackDivider,
     VStack,
 } from '@chakra-ui/react';
-import { ArrowLeftIcon } from '@heroicons/react/outline';
+import {
+    ArrowLeftIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from '@heroicons/react/outline';
 import { useNavigate } from 'react-router-dom';
 import {
     useApproveBoundaryMutation,
@@ -16,7 +20,6 @@ import {
     useUnapproveBoundaryMutation,
 } from '../../../api/boundaries';
 import CenteredSpinner from '../../CenteredSpinner';
-import { CheckCircleIcon } from '@heroicons/react/outline';
 
 import ActivityLog from '../ActivityLog';
 import { StatusBadge } from '../Badges';
@@ -146,7 +149,7 @@ export default function SubmissionDetail() {
                         <Button
                             mb={4}
                             alignSelf='flex-end'
-                            rightIcon={heroToChakraIcon(CheckCircleIcon)()}
+                            rightIcon={heroToChakraIcon(XCircleIcon)()}
                             onClick={() => unapproveBoundary(boundary.id)}
                         >
                             Mark unapproved

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -5,6 +5,7 @@ import {
     Flex,
     Heading,
     Icon,
+    Link,
     Spacer,
     Spinner,
     Tabs,
@@ -69,13 +70,22 @@ export default function SubmissionsList() {
             <Flex>
                 <Heading size='lg'>Submissions</Heading>
                 <Spacer />
-                <Button
-                    mr={4}
-                    disabled={boundaries?.length > 0}
-                    onClick={() => navigate('/welcome')}
-                >
-                    Add map
-                </Button>
+                {user.role === ROLES.ADMINISTRATOR && (
+                    <Link href='/api/export/boundaries/approved/' isExternal>
+                        <Button as='a' mr={4}>
+                            Export approved boundaries
+                        </Button>
+                    </Link>
+                )}
+                {userIsContributor && (
+                    <Button
+                        mr={4}
+                        disabled={boundaries?.length > 0}
+                        onClick={() => navigate('/welcome')}
+                    >
+                        Add map
+                    </Button>
+                )}
             </Flex>
             <Tabs mt={3} isLazy>
                 <TabList borderBottom='0' mb={6}>

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -6,6 +6,10 @@ import {
     Heading,
     Icon,
     Link,
+    Menu,
+    MenuButton,
+    MenuItem,
+    MenuList,
     Spacer,
     Spinner,
     Tabs,
@@ -23,6 +27,7 @@ import {
     Text,
 } from '@chakra-ui/react';
 import {
+    ChevronDownIcon,
     ClockIcon,
     FlagIcon,
     LocationMarkerIcon,
@@ -70,13 +75,7 @@ export default function SubmissionsList() {
             <Flex>
                 <Heading size='lg'>Submissions</Heading>
                 <Spacer />
-                {user.role === ROLES.ADMINISTRATOR && (
-                    <Link href='/api/export/boundaries/approved/' isExternal>
-                        <Button as='a' mr={4}>
-                            Export approved boundaries
-                        </Button>
-                    </Link>
-                )}
+                {user.role === ROLES.ADMINISTRATOR && <ExportControl />}
                 {userIsContributor && (
                     <Button
                         mr={4}
@@ -203,5 +202,26 @@ function ErrorRow({ error }) {
             <Td>There was an error fetching data. Details: {error}</Td>
             <Td />
         </Tr>
+    );
+}
+
+function ExportControl() {
+    return (
+        <Menu>
+            <MenuButton
+                as={Button}
+                rightIcon={<Icon as={heroToChakraIcon(ChevronDownIcon)} />}
+            >
+                Export
+            </MenuButton>
+            <MenuList>
+                <Link href='/api/export/boundaries/all/' isExternal>
+                    <MenuItem>All boundaries</MenuItem>
+                </Link>
+                <Link href='/api/export/boundaries/approved/' isExternal>
+                    <MenuItem>Approved boundaries only</MenuItem>
+                </Link>
+            </MenuList>
+        </Menu>
     );
 }

--- a/src/app/src/pages/Submissions.js
+++ b/src/app/src/pages/Submissions.js
@@ -9,7 +9,7 @@ export default function Submissions() {
             <Route
                 index
                 element={
-                    <WithNavbar>
+                    <WithNavbar variant={NAVBAR_VARIANTS.LIST}>
                         <List />
                     </WithNavbar>
                 }
@@ -17,7 +17,7 @@ export default function Submissions() {
             <Route
                 path=':boundaryId'
                 element={
-                    <WithNavbar>
+                    <WithNavbar variant={NAVBAR_VARIANTS.DETAIL}>
                         <Detail />
                     </WithNavbar>
                 }
@@ -34,7 +34,7 @@ export default function Submissions() {
     );
 }
 
-function WithNavbar({ variant = NAVBAR_VARIANTS.SUBMISSION, children }) {
+function WithNavbar({ variant, children }) {
     return (
         <>
             <NavBar variant={variant} />

--- a/src/django/api/permissions.py
+++ b/src/django/api/permissions.py
@@ -35,3 +35,13 @@ class UserCanUnapproveBoundaries(BasePermission):
             request.user.role == Roles.VALIDATOR
             or request.user.role == Roles.ADMINISTRATOR
         )
+
+
+class UserIsAdmin(BasePermission):
+    message = 'You are not an administrator.'
+
+    def has_permission(self, request, view):
+        if not request.user.is_active:
+            return False
+
+        return request.user.role == Roles.ADMINISTRATOR

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -13,7 +13,7 @@ from .views.boundary import (
     BoundarySubmitView,
     BoundaryUnapproveView,
 )
-from .views.export import boundaries_approved
+from .views.export import boundaries_all, boundaries_approved
 from .views.reference_image import ReferenceImageDetail, ReferenceImageList
 from .views.review import ReviewCreateView, ReviewFinishView
 
@@ -74,6 +74,11 @@ urlpatterns = [
         "boundaries/<int:boundary_id>/unapprove/",
         BoundaryUnapproveView.as_view(),
         name='unapprove_boundary',
+    ),
+    path(
+        "export/boundaries/all/",
+        boundaries_all,
+        name='export_boundaries_all',
     ),
     path(
         "export/boundaries/approved/",

--- a/src/django/api/urls.py
+++ b/src/django/api/urls.py
@@ -13,6 +13,7 @@ from .views.boundary import (
     BoundarySubmitView,
     BoundaryUnapproveView,
 )
+from .views.export import boundaries_approved
 from .views.reference_image import ReferenceImageDetail, ReferenceImageList
 from .views.review import ReviewCreateView, ReviewFinishView
 
@@ -73,6 +74,11 @@ urlpatterns = [
         "boundaries/<int:boundary_id>/unapprove/",
         BoundaryUnapproveView.as_view(),
         name='unapprove_boundary',
+    ),
+    path(
+        "export/boundaries/approved/",
+        boundaries_approved,
+        name='export_boundaries_approved',
     ),
 ]
 

--- a/src/django/api/views/export.py
+++ b/src/django/api/views/export.py
@@ -1,0 +1,64 @@
+from datetime import datetime
+
+from django.db import connection
+from django.http import HttpResponse
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+
+from api.permissions import UserIsAdmin
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated, UserIsAdmin])
+def boundaries_approved(request):
+    query = """
+    WITH features AS (
+        SELECT json_build_object(
+            'type',       'Feature',
+            'id',         b.id,
+            'geometry',   ST_AsGeoJSON(shape)::json,
+            'properties', json_build_object(
+                'name',            u.name,
+                'pwsid',           u.pwsid,
+                'city',            u.address_city,
+                'state',           u.state_id,
+                'drafted_at',      s.created_at,
+                'drafted_by',      du.email,
+                'submitted_at',    s.submitted_at,
+                'submitted_by',    su.email,
+                'submitted_notes', s.notes,
+                'approved_at',     a.approved_at,
+                'approved_by',     au.email,
+                'status',          'Approved'
+            )
+        ) AS feature
+        FROM api_approval a
+            INNER JOIN api_user au ON a.approved_by_id = au.id
+            INNER JOIN api_submission s ON a.submission_id = s.id
+            INNER JOIN api_user du ON s.created_by_id = su.id
+            INNER JOIN api_user su ON s.submitted_by_id = su.id
+            INNER JOIN api_boundary b ON s.boundary_id = b.id
+            INNER JOIN api_utility u ON b.utility_id = u.id
+        WHERE a.unapproved_at IS NULL
+    )
+
+    SELECT json_build_object(
+        'type',     'FeatureCollection',
+        'features', json_agg(features.feature)
+    )::text
+
+    FROM features;
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(query)
+        result = cursor.fetchone()[0]
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    response = HttpResponse(result, content_type="application/json")
+    response[
+        "Content-Disposition"
+    ] = f"attachment; filename=approved_boundaries_{timestamp}.geojson"
+
+    return response

--- a/src/django/api/views/export.py
+++ b/src/django/api/views/export.py
@@ -62,3 +62,93 @@ def boundaries_approved(request):
     ] = f"attachment; filename=approved_boundaries_{timestamp}.geojson"
 
     return response
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated, UserIsAdmin])
+def boundaries_all(request):
+    query = """
+    WITH features AS (
+        SELECT json_build_object(
+            'type',       'Feature',
+            'id',         b.id,
+            'geometry',   ST_AsGeoJSON(shape)::json,
+            'properties', json_build_object(
+                'name',            u.name,
+                'pwsid',           u.pwsid,
+                'city',            u.address_city,
+                'state',           u.state_id,
+                'drafted_at',      s.created_at,
+                'drafted_by',      du.email,
+                'submitted_at',    s.submitted_at,
+                'submitted_by',    su.email,
+                'submitted_notes', s.notes,
+                'reviewed_at',     r.reviewed_at,
+                'reviewed_by',     ru.email,
+                'reviewed_notes',  r.notes,
+                'approved_at',     a.approved_at,
+                'approved_by',     au.email,
+                'status',          CASE
+                                       WHEN s.submitted_at IS NULL THEN 'Draft'
+                                       WHEN r.id IS NOT NULL
+                                           AND r.reviewed_at IS NULL
+                                           THEN 'In Review'
+                                       WHEN r.id IS NOT NULL
+                                           AND r.reviewed_at IS NOT NULL
+                                           THEN 'Needs Revisions'
+                                       WHEN a.approved_at IS NOT NULL
+                                           AND a.unapproved_at IS NULL
+                                           THEN 'Approved'
+                                       ELSE 'Submitted'
+                                   END
+            )
+        ) AS feature
+        FROM api_boundary b
+            INNER JOIN api_utility u ON u.id = b.utility_id
+            LEFT JOIN LATERAL (
+                SELECT *
+                FROM api_submission
+                WHERE boundary_id = b.id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) s ON TRUE
+            LEFT JOIN api_user du ON s.created_by_id = du.id
+            LEFT JOIN api_user su ON s.submitted_by_id = su.id
+            LEFT JOIN LATERAL (
+                SELECT *
+                FROM api_review
+                WHERE submission_id = s.id
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) r ON TRUE
+            LEFT JOIN api_user ru ON r.reviewed_by_id = ru.id
+            LEFT JOIN LATERAL (
+                SELECT *
+                FROM api_approval
+                WHERE submission_id = s.id
+                ORDER BY approved_at DESC
+                LIMIT 1
+            ) a ON TRUE
+            LEFT JOIN api_user au ON a.approved_by_id = au.id
+    )
+
+    SELECT json_build_object(
+        'type',     'FeatureCollection',
+        'features', json_agg(features.feature)
+    )::text
+
+    FROM features;
+    """
+
+    with connection.cursor() as cursor:
+        cursor.execute(query)
+        result = cursor.fetchone()[0]
+
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+
+    response = HttpResponse(result, content_type="application/json")
+    response[
+        "Content-Disposition"
+    ] = f"attachment; filename=all_boundaries_{timestamp}.geojson"
+
+    return response


### PR DESCRIPTION
## Overview

Adds two new endpoints to export boundaries: one for only approved boundaries, and one for all boundaries. Adds a button in the front-end for administrators to do so.

Also cleans up some minor issues.

Closes #216 
Closes #172 
Closes #93 
Closes #211 
Closes #184 

### Demo

![image](https://user-images.githubusercontent.com/1430060/203607187-47292472-1d2f-4430-a1d4-452f56fa021d.png)

![image](https://user-images.githubusercontent.com/1430060/203608351-d81485b4-0451-41c7-8b8c-82853c0658e4.png)

### Notes

5e6fbf2d8f6c7318bceff46209fbf3d1f3c34289 was done when I thought that the button would live in the List NavBar, but in the end it made more sense to place it on the main page itself. It can be excluded, but I think it is still valuable, so kept it in.

## Testing Instructions

- Checkout this branch and `server`
- Login as an Administrator
- Go to the Submissions List
  - [x] Ensure you see a button to export boundaries
  - [x] Ensure you are able to export all boundaries
  - [x] Ensure you are able to export approved boundaries
- Log out, and login as a Contributor
- Open this URL: http://localhost:4545/submissions/1
- ~~Select "Other Utility" in the selector dropdown~~
  - [ ] ~~Ensure the loaded page says "Azavea Test Utility" in the top-left, not "Other Utility"~~
  - [x] Ensure you do not see the utility selector dropdown
  - [x] Ensure the loaded page says "Azavea Test Utility" in the top-left
- Open this URL: http://localhost:4545/submissions
  - [x] Ensure you do see the utility selector dropdown
  - [x] Ensure you are taken to the appropriate submissions list after

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
