### PR TITLE
GitHub Action permissions issue workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix submit boundary [#195](https://github.com/azavea/iow-boundary-tool/pull/195)
 - Fix contributor welcome redirect [#197](https://github.com/azavea/iow-boundary-tool/pull/197)
 - Memoize shape update functions [#210](https://github.com/azavea/iow-boundary-tool/pull/210)
+- GitHub Actions permissions issue workaround [#219](https://github.com/azavea/iow-boundary-tool/pull/219)
 
 ### Deprecated
 

--- a/scripts/infra
+++ b/scripts/infra
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+git config --global --add safe.directory /usr/local/src
 
 if [[ -n "${IOW_BOUNDARY_TOOL_DEBUG}" ]]; then
     set -x


### PR DESCRIPTION
## Overview

After PR #213 was merged into develop, the [GitHub Action workflow CI](https://github.com/azavea/iow-boundary-tool/actions/runs/3536214944/jobs/5935038264) failed with the following error:

```
fatal: unsafe repository ('/usr/local/src' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /usr/local/src
```

Investigation found that this is a known issue regarding Ubuntu 20.04 containers running docker images after Ubuntu patched [git](http://changelogs.ubuntu.com/changelogs/pool/main/g/git/git_2.25.1-1ubuntu3.3/changelog), causing a breaking behavior and a security fix without any version bump.  Suspect the upgrade of our terraform container brought with it an upgrade to git.

Addresses CI failure in PR #213 

### Demo

Failed CI run: https://github.com/azavea/iow-boundary-tool/actions/runs/3536214944/jobs/5935038264
Working CI run: https://github.com/azavea/iow-boundary-tool/pull/220

### Notes

- CHANGELOG.md will be updated upon successful completion of CI run and review approval.
- Additional reference, OAR: https://github.com/open-apparel-registry/open-apparel-registry/pull/2058

## Testing Instructions

- Review GitHub Action workflow to verify if completed successfully (see second link under demo)

## Checklist

- [x] `fixup!` commits have been squashed
- [ ] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
