### PR TITLE
Fix geojson uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix geojson uploads [#223](https://github.com/azavea/iow-boundary-tool/pull/223)
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
## Overview

Previously we would naively parse any uploaded GeoJSON files, assuming them all to be polygon geometries. This hardens that, so that if a user uploads a FeatureCollection or a Feature, we extract the first Polygon geometry from within that to parse. If no parseable geometry is found, an error is returned.

Fixes #222

### Demo

![image](https://user-images.githubusercontent.com/1430060/204655371-2717748a-68f6-46fe-9018-479b3ab55d9d.png)

## Testing Instructions

- Checkout this branch and `update` and `resetdb` and `server`
- Download this file: [owasa.geojson.gz](https://github.com/azavea/iow-boundary-tool/files/10116172/owasa.geojson.gz) and extract it:
    ```
    gzip -d owasa.geojson.gz
    ```
- Go to http://localhost:4545/ and login as `c1@azavea.com`
- Select the Other Utility
- Upload the resulting `owasa.geojson` file in the Welcome dialog
  - [x] Ensure it gets added correctly
- Click the Replace polygon and upload the file again using the Replace Polygon modal
  - [x] Ensure it gets added correctly

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
