### PR TITLE
Remove showmigrations from CI / Release pipelines

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -52,11 +52,3 @@ jobs:
           startsWith(github.ref, 'refs/heads/hotfix/') ||
           startsWith(github.ref, 'refs/heads/release/') ||
           startsWith(github.ref, 'refs/heads/test/')
-
-      # Kick off an ECS task to display any outstanding migrations.
-      - run: ./scripts/manage ecsmanage showmigrations
-        if: |
-          github.ref == 'refs/heads/develop' ||
-          startsWith(github.ref, 'refs/heads/hotfix/') ||
-          startsWith(github.ref, 'refs/heads/release/') ||
-          startsWith(github.ref, 'refs/heads/test/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,3 @@ jobs:
             ./scripts/infra plan
             ./scripts/infra apply
           "
-
-      # Kick off an ECS task to display any outstanding migrations.
-      - run: ./scripts/manage ecsmanage -e production showmigrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove `showmigrations` step from CI / Release pipelines [#224](https://github.com/azavea/iow-boundary-tool/pull/224)
+
 ### Security
 
 ## [0.9.1] - 2022-11-28


### PR DESCRIPTION
## Overview

This step was not used and caused significant delays to CI jobs. For example, see here:

https://github.com/azavea/iow-boundary-tool/actions/runs/3566198623/jobs/5992333569

The deployment takes ~28s, and showmigrations took 1m41s.

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [ ] CI passes after rebase
