### PR TITLE
Fix adding annotations on top of boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix geojson uploads [#223](https://github.com/azavea/iow-boundary-tool/pull/223)
+- Fix adding annotations on top of boundary [#226](https://github.com/azavea/iow-boundary-tool/pull/226)
 
 ### Deprecated
 
 ### Removed
 
 - Remove `showmigrations` step from CI / Release pipelines [#224](https://github.com/azavea/iow-boundary-tool/pull/224)
+- Remove Archived tab [#226](https://github.com/azavea/iow-boundary-tool/pull/226)
 
 ### Security
 

--- a/src/app/src/components/DrawTools/useEditingPolygon.js
+++ b/src/app/src/components/DrawTools/useEditingPolygon.js
@@ -89,6 +89,7 @@ export default function useEditingPolygon() {
 
     useEffect(() => {
         if (shape && polygonIsVisible) {
+            const interactive = canWrite && editMode;
             const polygonLayer = new L.Polygon(
                 shape.coordinates[0].map(
                     point => new L.latLng(point[1], point[0])
@@ -96,10 +97,11 @@ export default function useEditingPolygon() {
                 {
                     ...POLYGON_LAYER_OPTIONS,
                     color: basemapType === 'satellite' ? 'white' : 'black',
+                    interactive,
                 }
             );
 
-            if (canWrite && editMode) {
+            if (interactive) {
                 polygonLayer.editing.enable();
             }
 

--- a/src/app/src/components/Submissions/List.js
+++ b/src/app/src/components/Submissions/List.js
@@ -12,11 +12,6 @@ import {
     MenuList,
     Spacer,
     Spinner,
-    Tabs,
-    TabList,
-    TabPanels,
-    Tab,
-    TabPanel,
     Table,
     Thead,
     Tbody,
@@ -86,31 +81,18 @@ export default function SubmissionsList() {
                     </Button>
                 )}
             </Flex>
-            <Tabs mt={3} isLazy>
-                <TabList borderBottom='0' mb={6}>
-                    <Tab>Active</Tab>
-                    <Tab isDisabled>Archived</Tab>
-                </TabList>
-
-                <TabPanels>
-                    <TabPanel>
-                        <TableContainer borderRadius='2px'>
-                            <Table variant='submissions'>
-                                <TableHeader />
-                                <Tbody>
-                                    <TableRows
-                                        isFetching={isFetching}
-                                        error={error}
-                                        boundaries={boundaries}
-                                    />
-                                </Tbody>
-                            </Table>
-                        </TableContainer>
-                    </TabPanel>
-                    {/* TODO Implement Archived Tab */}
-                    <TabPanel></TabPanel>
-                </TabPanels>
-            </Tabs>
+            <TableContainer mt={6} borderRadius='2px'>
+                <Table variant='submissions'>
+                    <TableHeader />
+                    <Tbody>
+                        <TableRows
+                            isFetching={isFetching}
+                            error={error}
+                            boundaries={boundaries}
+                        />
+                    </Tbody>
+                </Table>
+            </TableContainer>
         </Box>
     );
 }


### PR DESCRIPTION
## Overview

Previously, the annotation clicks would be captured by the polygon. Now we mark it as not interactive if the user cannot write or if the shape is not in edit mode, which allows the clicks to pass through to the map, allowing Validators to add annotations within the boundary.

Also removes the Archived tab in the submissions list.

Closes #225 
Closes #227 

### Demo

https://user-images.githubusercontent.com/1430060/205735421-07661311-2f7b-42ef-ab8a-99fee32d5484.mp4

![image](https://user-images.githubusercontent.com/1430060/205967711-8242c774-3337-4d51-836a-7c7894caf476.png)

## Testing Instructions

- Check out this branch and `server`
- Go to http://localhost:4545/ and login as a Validator
- Pick an In Review submission and go to the details and draw page
- Try adding annotations
  - [x] Ensure you can add annotations both inside and outside the shape
  - [x] Ensure you can delete annotations both inside and outside the shape
- With a sample annotation within and outside the boundary, mark that boundary as Needs Revisions
- Logout and log back in as a Contributor
- Pick the Needs Revisions submission and amend it
  - [x] Ensure you can access annotations within and without the shape
  - [x] Ensure you can edit the shape
- Go to /submissions/
  - [x] Ensure you don't see an Archived tab, or Active tab

## Checklist

- [ ] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [ ] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
