### PR TITLE
Add management command to bulk import contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ deployment/ansible/roles/azavea.*
 /src/django/data/
 /src/django/media/
 /.venv
+/src/django/**/*.log
 
 # JS
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add management command to bulk import contributors [#238](https://github.com/azavea/iow-boundary-tool/pull/238)
+
 ### Changed
 
 ### Fixed

--- a/deployment/terraform/iam.tf
+++ b/deployment/terraform/iam.tf
@@ -76,3 +76,24 @@ resource "aws_iam_role_policy" "s3_read_write_data_bucket" {
     role   = aws_iam_role.ecs_task_role.name
     policy = data.aws_iam_policy_document.s3_read_write_data_bucket.json
 }
+
+data "aws_iam_policy_document" "s3_write_logs_bucket" {
+    statement {
+        effect = "Allow"
+
+        resources = [
+            aws_s3_bucket.logs.arn,
+            "${aws_s3_bucket.logs.arn}/*",
+        ]
+
+        actions = [
+            "s3:PutObject",
+        ]
+    }
+}
+
+resource "aws_iam_role_policy" "s3_write_logs_bucket" {
+    name   = "S3WriteLogs"
+    role   = aws_iam_role.ecs_task_role.name
+    policy = data.aws_iam_policy_document.s3_write_logs_bucket.json
+}

--- a/src/django/api/management/commands/create_contributors_from_s3.py
+++ b/src/django/api/management/commands/create_contributors_from_s3.py
@@ -1,0 +1,103 @@
+import csv
+import logging
+import sys
+from datetime import datetime
+
+import boto3
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from api.models import Roles, User, Utility
+
+
+class Command(BaseCommand):
+    help = "Create User models from a CSV file in S3"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger = logging.getLogger("django")
+        self.logfile = f"create_contributors_from_s3_{datetime.now().isoformat()}.log"
+
+        file_handler = logging.FileHandler(self.logfile)
+        formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+
+        file_handler.setFormatter(formatter)
+        self.logger.addHandler(file_handler)
+
+    def add_arguments(self, parser):
+        parser.add_argument("bucket_name", type=str, help="Name of the S3 bucket")
+        parser.add_argument(
+            "csv_file_key", type=str, help="Key of the CSV file in the S3 bucket"
+        )
+
+    def handle(self, *args, **options):
+        bucket_name = options["bucket_name"]
+        csv_file_key = options["csv_file_key"]
+        s3 = boto3.client("s3")
+
+        try:
+            # Fetch the specified CSV file from S3
+            response = s3.get_object(Bucket=bucket_name, Key=csv_file_key)
+            content = response["Body"].read().decode("utf-8")
+            reader = csv.DictReader(content.splitlines())
+
+            # We process the CSV file atomically, so if there's any errors encountered,
+            # the entire import is cancelled
+            with transaction.atomic():
+                try:
+                    for row in reader:
+                        # Create a user with specified utilities for each row in CSV
+                        user = User.objects.create_user(
+                            email=row["email"],
+                            role=Roles.CONTRIBUTOR,
+                            password=row["password"],
+                            full_name=row["full_name"],
+                            phone_number=row["phone_number"],
+                            job_title=row["job_title"],
+                        )
+
+                        # Associate with utilities matching given ; separated PWSIDs.
+                        # We don't use .filter(pwsid__in) here because we want to fail
+                        # if any given PWSID is not found in the system to call out
+                        # mistakes in input CSV.
+                        pwsids = row["pwsids"].split(";")
+                        utilities = []
+                        for pwsid in pwsids:
+                            try:
+                                utilities.append(Utility.objects.get(pwsid=pwsid))
+                            except Utility.DoesNotExist:
+                                self.logger.error(
+                                    f"Invalid PWSID '{pwsid}' "
+                                    f"for contributor {user.email}"
+                                )
+                                raise
+
+                        user.utilities.set(utilities)
+
+                        utilities_str = ", ".join(
+                            [str(ut) for ut in user.utilities.all()]
+                        )
+
+                        self.logger.info(
+                            f"Successfully created contributor {user.email}, "
+                            f"associated with {utilities_str}"
+                        )
+
+                except Exception as e:
+                    self.logger.error(
+                        f"Error occurred during contributor creation: {str(e)}"
+                    )
+                    transaction.set_rollback(True)
+                    sys.exit(1)
+        except ClientError as e:
+            self.logger.error(f"Error occurred while accessing the CSV file: {str(e)}")
+            sys.exit(1)
+        finally:
+            if settings.ENVIRONMENT != "Development":
+                # Upload log to S3
+                log_file_key = f"management/{self.logfile}"
+                s3.upload_file(
+                    self.logfile, settings.AWS_LOGS_BUCKET_NAME, log_file_key
+                )

--- a/src/django/api/models/user.py
+++ b/src/django/api/models/user.py
@@ -19,7 +19,7 @@ class EmailAsUsernameUserManager(BaseUserManager):
 
     use_in_migrations = True
 
-    def _create_user(self, email, role, password=None, **extra_fields):
+    def _create_user(self, email, role, password=None, validate=True, **extra_fields):
         if not email:
             raise ValueError("An email address must be provided.")
         if not role:
@@ -27,6 +27,8 @@ class EmailAsUsernameUserManager(BaseUserManager):
         email = self.normalize_email(email)
         user = self.model(email=email, role=role, **extra_fields)
         user.set_password(password)
+        if validate:
+            user.full_clean()
         user.save()
         return user
 

--- a/src/django/iow/settings.py
+++ b/src/django/iow/settings.py
@@ -305,6 +305,7 @@ if ENVIRONMENT != 'Development':
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = f"/media/"
 AWS_STORAGE_BUCKET_NAME = f'iow-{ENVIRONMENT.lower()}-data-us-east-1'
+AWS_LOGS_BUCKET_NAME = f'iow-{ENVIRONMENT.lower()}-logs-us-east-1'
 
 # IOW Settings
 


### PR DESCRIPTION
## Overview

This management command reads a CSV file from S3, and creates a contributor user associated with the utilities having given PWSIDs for each row in the CSV.

This command can be run locally or on AWS using `ecsmanage`:

```bash
./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-success.csv
```

```bash
./scripts/manage ecsmanage create_contributors_from_s3 iow-staging-data-us-east-1 csv/test-contributors-success.csv
```

The output is logged to the console, and also to a file timestamped to each run. In the case of AWS environments, that file is also sent to the corresponding logs bucket.

The ECS tasks are given additional permissions to be able to write to that bucket.

The local log files are added to `.gitignore`.

This procedure is documented in the Data README.

Closes #236 

### Demo

#### Success

```bash
./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-success.csv

[+] Running 1/0
 ✔ Container iow-boundary-tool-database-1  Running                                                                                                                                                                                       0.0s
Successfully created contributor c2@element84.com, associated with 123456789 - Azavea Test Utility
Successfully created contributor c3@element84.com, associated with 123456789 - Azavea Test Utility, OTHERUTIL - Other Utility
```

#### Failure

```bash
./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-bad-pwsid.csv

[+] Running 1/0
 ✔ Container iow-boundary-tool-database-1  Running                                                                                                                                                                                       0.0s
Successfully created contributor c2@element84.com, associated with 123456789 - Azavea Test Utility
Invalid PWSID 'OTHER' for contributor c3@element84.com
Error occurred during contributor creation: Utility matching query does not exist.
kj: callProcess: /Users/ttuhinanshu/dev/iow-boundary-tool/scripts/manage "create_contributors_from_s3" "iow-development-data-us-east-1" "csv/test-contributors-bad-pwsid.csv" (exit 1): failed
```

## Testing Instructions

- Check out this branch and run `./scripts/manage resetdb`
- Try a couple of failure cases, ensure they fail with the appropriate message:
  - [x] `./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-bad-pwsid.csv`
  - [x] `./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-missing-phone.csv`
  - [x] `./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-bad-email.csv`
- [ ] Create any other failure cases that you want to test, upload them to `s3://iow-development-data-us-east-1/csv/` and ensure they also fail
- Run the success case and ensure it succeeds:
  - [x] `./scripts/manage create_contributors_from_s3 iow-development-data-us-east-1 csv/test-contributors-success.csv`
  - [x] Ensure that you are able to login as one of the successfully imported contributors
  - [x] Ensure that you are prompted to change your password after first login
  - [x] Ensure that all contributor users are associated with the correct utilities
- Read through the instructions in `data/README.md` and ensure they make sense

## Checklist

- [x] `fixup!` commits have been squashed
- [x] `CHANGELOG.md` updated with summary of features or fixes, following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines
- [x] `README.md` updated if necessary to reflect the changes
- [x] CI passes after rebase
